### PR TITLE
feat: 카카오 소셜 로그인 & 로그아웃 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,15 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //.env 읽어서 환경설정변수를 주입해주는 의존성
+    implementation 'io.github.cdimascio:dotenv-java:3.0.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kakaotechcampus/team16be/Team16BeApplication.java
+++ b/src/main/java/com/kakaotechcampus/team16be/Team16BeApplication.java
@@ -1,5 +1,6 @@
 package com.kakaotechcampus.team16be;
 
+import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,6 +8,14 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class Team16BeApplication {
 
     public static void main(String[] args) {
+        Dotenv dotenv = Dotenv.configure()
+                .directory("./")  // 최상위 폴더에 .env 위치
+                .load();
+
+        System.setProperty("JWT_SECRET_KEY", dotenv.get("JWT_SECRET_KEY"));
+        System.setProperty("KAKAO_CLIENT_ID", dotenv.get("KAKAO_CLIENT_ID"));
+        System.setProperty("KAKAO_REDIRECT_URI", dotenv.get("KAKAO_REDIRECT_URI"));
+
         SpringApplication.run(Team16BeApplication.class, args);
     }
 

--- a/src/main/java/com/kakaotechcampus/team16be/auth/client/KakaoAuthClient.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/client/KakaoAuthClient.java
@@ -1,0 +1,170 @@
+package com.kakaotechcampus.team16be.auth.client;
+
+import com.kakaotechcampus.team16be.auth.config.KakaoProperties;
+import com.kakaotechcampus.team16be.auth.dto.KakaoTokenResponse;
+import com.kakaotechcampus.team16be.auth.dto.KakaoUserInfoResponse;
+import com.kakaotechcampus.team16be.auth.exception.KakaoErrorCode;
+import com.kakaotechcampus.team16be.auth.exception.KakaoException;
+import org.springframework.stereotype.Component;
+import org.springframework.http.*;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class KakaoAuthClient {
+
+    // 카카오 API URL 상수
+    private static final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+    private static final String KAKAO_LOGOUT_URL = "https://kapi.kakao.com/v1/user/logout";
+
+    private final KakaoProperties kakaoProperties;
+    private final RestTemplate restTemplate;
+
+    // 생성자 주입
+    public KakaoAuthClient(KakaoProperties kakaoProperties, RestTemplate restTemplate) {
+        this.kakaoProperties = kakaoProperties;
+        this.restTemplate = restTemplate;
+    }
+
+    /**
+     * 인가 코드(code)를 사용하여 카카오에서 Access Token 요청
+     * @param code 프론트에서 받은 인가 코드
+     * @return KaKaoTokenResponse 액세스 토큰 정보
+     */
+    public KakaoTokenResponse requestAccessToken(String code) {
+        HttpEntity<MultiValueMap<String, String>> request = buildTokenRequestEntity(code);
+
+        try {
+            ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
+                    KAKAO_TOKEN_URL,
+                    HttpMethod.POST,
+                    request,
+                    KakaoTokenResponse.class
+            );
+
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                throw new KakaoException(KakaoErrorCode.TOKEN_REQUEST_FAILED);
+            }
+
+            KakaoTokenResponse tokenResponse = response.getBody();
+            if (tokenResponse == null || tokenResponse.accessToken() == null) {
+                throw new KakaoException(KakaoErrorCode.TOKEN_REQUEST_FAILED);
+            }
+
+            return tokenResponse;
+
+        } catch (HttpClientErrorException | HttpServerErrorException ex) {
+            throw new KakaoException(KakaoErrorCode.TOKEN_REQUEST_FAILED);
+        } catch (ResourceAccessException ex) {
+            throw new KakaoException(KakaoErrorCode.CONNECTION_FAILED);
+        }
+    }
+
+    /**
+     * Access Token을 사용하여 카카오에서 kakaoId 조회
+     * @param accessToken 카카오에서 발급받은 Access Token
+     * @return kakaoId
+     */
+    public String requestKakaoId(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken); // Bearer 방식 인증 헤더
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+        try {
+            ResponseEntity<KakaoUserInfoResponse> response = restTemplate.exchange(
+                    KAKAO_USER_INFO_URL,
+                    HttpMethod.GET,
+                    request,
+                    KakaoUserInfoResponse.class
+            );
+
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                throw new KakaoException(KakaoErrorCode.USER_INFO_REQUEST_FAILED);
+            }
+
+            KakaoUserInfoResponse userInfo = response.getBody();
+            if (userInfo == null || userInfo.kakaoId() == null) {
+                throw new KakaoException(KakaoErrorCode.USER_INFO_REQUEST_FAILED);
+            }
+
+            return String.valueOf(userInfo.kakaoId()); // kakaoId 반환
+
+        } catch (HttpClientErrorException | HttpServerErrorException ex) {
+            throw new KakaoException(KakaoErrorCode.USER_INFO_REQUEST_FAILED);
+        } catch (ResourceAccessException ex) {
+            throw new KakaoException(KakaoErrorCode.CONNECTION_FAILED);
+        }
+    }
+
+    //카카오 유저 정보 한번에 가져옴
+    public KakaoUserInfoResponse requestKakaoUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<KakaoUserInfoResponse> response = restTemplate.exchange(
+                    KAKAO_USER_INFO_URL,
+                    HttpMethod.GET,
+                    request,
+                    KakaoUserInfoResponse.class
+            );
+
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                throw new KakaoException(KakaoErrorCode.USER_INFO_REQUEST_FAILED);
+            }
+
+            KakaoUserInfoResponse userInfo = response.getBody();
+            if (userInfo == null || userInfo.kakaoId() == null) {
+                throw new KakaoException(KakaoErrorCode.USER_INFO_REQUEST_FAILED);
+            }
+
+            return userInfo;
+
+        } catch (HttpClientErrorException | HttpServerErrorException ex) {
+            throw new KakaoException(KakaoErrorCode.USER_INFO_REQUEST_FAILED);
+        } catch (ResourceAccessException ex) {
+            throw new KakaoException(KakaoErrorCode.CONNECTION_FAILED);
+        }
+    }
+
+
+    public void kakaoLogout(String accessToken) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(accessToken);
+            HttpEntity<Void> request = new HttpEntity<>(headers);
+
+            restTemplate.exchange(
+                    KAKAO_LOGOUT_URL,
+                    HttpMethod.POST,
+                    request,
+                    String.class
+            );
+        } catch (HttpClientErrorException e) {
+            // 토큰 만료나 인증 실패 등 카카오 오류를 KakaoException으로 변환
+            throw new KakaoException(KakaoErrorCode.LOGOUT_FAILED);
+        }
+    }
+
+    // Access Token 요청을 위한 HttpEntity 생성
+    private HttpEntity<MultiValueMap<String, String>> buildTokenRequestEntity(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED); // form-data 방식
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", kakaoProperties.getClientId());
+        body.add("redirect_uri", kakaoProperties.getRedirectUri());
+        body.add("code", code);
+
+        return new HttpEntity<>(body, headers);
+    }
+
+}
+

--- a/src/main/java/com/kakaotechcampus/team16be/auth/config/KakaoProperties.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/config/KakaoProperties.java
@@ -1,0 +1,28 @@
+package com.kakaotechcampus.team16be.auth.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "kakao")
+public class KakaoProperties {
+
+    private String clientId;
+    private String redirectUri;
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getRedirectUri() {
+        return redirectUri;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public void setRedirectUri(String redirectUri) {
+        this.redirectUri = redirectUri;
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/auth/config/RestTemplateConfig.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/config/RestTemplateConfig.java
@@ -1,0 +1,25 @@
+package com.kakaotechcampus.team16be.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new  RestTemplate(clientHttpRequestFactory());
+    }
+
+    private ClientHttpRequestFactory clientHttpRequestFactory() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+
+        factory.setConnectTimeout(1000);  // 연결 시도 최대 1초
+        factory.setReadTimeout(3000);     // 읽기 시도 최대 3초
+
+        return factory;
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/controller/AuthController.java
@@ -1,0 +1,36 @@
+package com.kakaotechcampus.team16be.auth.controller;
+
+import com.kakaotechcampus.team16be.auth.dto.KakaoLoginResponse;
+import com.kakaotechcampus.team16be.auth.service.KakaoAuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final KakaoAuthService kakaoAuthService;
+
+    public AuthController(KakaoAuthService kakaoAuthService) {
+        this.kakaoAuthService = kakaoAuthService;
+    }
+
+    @PostMapping("/kakao-login")
+    public ResponseEntity<KakaoLoginResponse> kakaoLogin(
+            @RequestParam("code") String code,
+            HttpServletRequest request
+    ) {
+        KakaoLoginResponse kakaoLoginResponse = kakaoAuthService.loginWithCode(code, request);
+        return ResponseEntity.ok(kakaoLoginResponse);
+    }
+
+    @PostMapping("/kakao-logout")
+    public ResponseEntity<Void> logout(HttpServletRequest request) {
+        kakaoAuthService.logout(request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/auth/dto/ErrorResponseDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/dto/ErrorResponseDto.java
@@ -1,0 +1,20 @@
+package com.kakaotechcampus.team16be.auth.dto;
+
+public class ErrorResponseDto {
+    private final String message;
+    private final int status;  // HTTP 상태 코드
+
+    public ErrorResponseDto(String message, int status) {
+        this.message = message;
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/auth/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/dto/KakaoLoginResponse.java
@@ -1,0 +1,6 @@
+package com.kakaotechcampus.team16be.auth.dto;
+
+public record KakaoLoginResponse (
+        String accessToken
+){
+}

--- a/src/main/java/com/kakaotechcampus/team16be/auth/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/dto/KakaoTokenResponse.java
@@ -1,0 +1,12 @@
+package com.kakaotechcampus.team16be.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoTokenResponse(
+        @JsonProperty("access_token")
+        String accessToken,
+
+        @JsonProperty("expires_in")
+        int expiresIn
+) {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/auth/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/dto/KakaoUserInfoResponse.java
@@ -1,0 +1,8 @@
+package com.kakaotechcampus.team16be.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserInfoResponse(
+        @JsonProperty("id")
+        Long kakaoId
+) {}

--- a/src/main/java/com/kakaotechcampus/team16be/auth/exception/AuthExceptionHandler.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/exception/AuthExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.kakaotechcampus.team16be.auth.exception;
+
+import com.kakaotechcampus.team16be.auth.dto.ErrorResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class AuthExceptionHandler {
+
+    @ExceptionHandler(JwtException.class)
+    public ResponseEntity<ErrorResponseDto> handleJwtException(JwtException e) {
+        return buildErrorResponse(
+                e.getErrorCode().getMessage(),
+                e.getErrorCode().getHttpStatus().value()
+        );
+    }
+
+    @ExceptionHandler(KakaoException.class)
+    public ResponseEntity<ErrorResponseDto> handleKakaoException(KakaoException e) {
+        return buildErrorResponse(
+                e.getErrorCode().getMessage(),
+                e.getErrorCode().getHttpStatus().value()
+        );
+    }
+
+    private ResponseEntity<ErrorResponseDto> buildErrorResponse(String message, int statusCode) {
+        return ResponseEntity
+                .status(statusCode)
+                .body(new ErrorResponseDto(message, statusCode));
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/auth/exception/JwtErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/exception/JwtErrorCode.java
@@ -1,0 +1,24 @@
+package com.kakaotechcampus.team16be.auth.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum JwtErrorCode {
+    // 401 Unauthorized
+    WRONG_HEADER_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 토큰입니다.");
+
+    private final HttpStatus httpStatus; // HTTP 상태 코드
+    private final String message; // 에러 메시지
+
+    JwtErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/auth/exception/JwtException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/exception/JwtException.java
@@ -1,0 +1,16 @@
+package com.kakaotechcampus.team16be.auth.exception;
+
+public class JwtException extends RuntimeException {
+
+    private final JwtErrorCode errorCode;
+
+    public JwtException(JwtErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public JwtErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/auth/exception/KakaoErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/exception/KakaoErrorCode.java
@@ -1,0 +1,31 @@
+package com.kakaotechcampus.team16be.auth.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum KakaoErrorCode {
+
+    // 500 INTERNAL_SERVER_ERROR
+    TOKEN_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 토큰 요청에 실패했습니다."),
+    USER_INFO_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 사용자 정보 요청에 실패했습니다."),
+    CONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 서버와의 연결에 실패했습니다."),
+    LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 로그아웃에 실패했습니다."),
+
+    // 503 SERVICE_UNAVAILABLE
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "카카오 서비스가 일시적으로 불가능합니다. 잠시 후 다시 시도해주세요.");
+
+    private final HttpStatus httpStatus; // HTTP 상태 코드
+    private final String message; // 에러 메시지
+
+    KakaoErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/auth/exception/KakaoException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/exception/KakaoException.java
@@ -1,0 +1,16 @@
+package com.kakaotechcampus.team16be.auth.exception;
+
+public class KakaoException extends RuntimeException {
+
+    private final KakaoErrorCode errorCode;
+
+    public KakaoException(KakaoErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public KakaoErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/jwt/JwtProvider.java
@@ -1,0 +1,88 @@
+package com.kakaotechcampus.team16be.auth.jwt;
+
+import com.kakaotechcampus.team16be.auth.exception.JwtErrorCode;
+import com.kakaotechcampus.team16be.auth.exception.JwtException;
+import com.kakaotechcampus.team16be.user.domain.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    public void init() {
+        // secretKey 초기화
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * JWT 토큰 생성
+     * @param user 토큰에 담을 User 정보
+     * @param expiresIn 토큰 만료 시간(초)
+     * @return JWT 문자열
+     */
+    public String createToken(User user, int expiresIn) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expiresIn * 1000L);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(user.getId()))
+                .claim("kakaoId", user.getKakaoId())
+                .setIssuedAt(now)
+                .setExpiration(expiryDate)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * JWT 파싱 및 검증
+     * @param token 클라이언트가 전달한 JWT
+     * @return Claims payload
+     */
+    public Claims parseToken(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (Exception e) {
+            throw new JwtException(JwtErrorCode.WRONG_HEADER_TOKEN);
+        }
+    }
+
+    /**
+     * JWT에서 userId 추출
+     */
+    public Long getUserId(String token) {
+        Claims claims = parseToken(token);
+        try {
+            return Long.parseLong(claims.getSubject());
+        } catch (NumberFormatException e) {
+            throw new JwtException(JwtErrorCode.WRONG_HEADER_TOKEN);
+        }
+    }
+
+    /**
+     * JWT에서 kakaoId 추출
+     */
+    public String getKakaoId(String token) {
+        Claims claims = parseToken(token);
+        Object kakaoId = claims.get("kakaoId");
+        return kakaoId != null ? kakaoId.toString() : null;
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/jwt/JwtProvider.java
@@ -42,6 +42,7 @@ public class JwtProvider {
         return Jwts.builder()
                 .setSubject(String.valueOf(user.getId()))
                 .claim("kakaoId", user.getKakaoId())
+                .claim("role", user.getRole().name())
                 .setIssuedAt(now)
                 .setExpiration(expiryDate)
                 .signWith(secretKey, SignatureAlgorithm.HS256)

--- a/src/main/java/com/kakaotechcampus/team16be/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/service/KakaoAuthService.java
@@ -1,0 +1,68 @@
+package com.kakaotechcampus.team16be.auth.service;
+
+import com.kakaotechcampus.team16be.auth.client.KakaoAuthClient;
+import com.kakaotechcampus.team16be.auth.dto.KakaoLoginResponse;
+import com.kakaotechcampus.team16be.auth.dto.KakaoTokenResponse;
+import com.kakaotechcampus.team16be.auth.dto.KakaoUserInfoResponse;
+import com.kakaotechcampus.team16be.auth.jwt.JwtProvider;
+import com.kakaotechcampus.team16be.user.domain.User;
+import com.kakaotechcampus.team16be.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class KakaoAuthService {
+
+    private final KakaoAuthClient kakaoAuthClient;
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    public KakaoAuthService(KakaoAuthClient kakaoAuthClient, UserRepository userRepository, JwtProvider jwtProvider) {
+        this.kakaoAuthClient = kakaoAuthClient;
+        this.userRepository = userRepository;
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Transactional
+    public KakaoLoginResponse loginWithCode(String code, HttpServletRequest request) {
+        // 1. 인가 코드로 Access Token 요청
+        KakaoTokenResponse kakaoTokenResponse = kakaoAuthClient.requestAccessToken(code);
+        String kakaoAccessToken = kakaoTokenResponse.accessToken();
+
+        // 2. Access Token으로 kakaoId 조회
+        KakaoUserInfoResponse kakaoUserInfo = kakaoAuthClient.requestKakaoUserInfo(kakaoAccessToken);
+        String kakaoId = String.valueOf(kakaoUserInfo.kakaoId());
+
+
+        // 3. kakaoId로 기존 회원 조회, 없으면 kakaoId 저장
+        User user = userRepository.findByKakaoId(kakaoId)
+                .orElseGet(() -> {
+                    User newUser = new User(kakaoId);
+                    return userRepository.save(newUser);
+                });
+
+        // 4. kakaoAccessToken을 세션에 저장
+        request.getSession().setAttribute("kakaoAccessToken", kakaoAccessToken);
+
+        // 5. JWT 발급 (만료시간은 카카오액세스토큰이랑 똑같이 설정함)
+        String accessToken = jwtProvider.createToken(user, kakaoTokenResponse.expiresIn());
+
+        return new KakaoLoginResponse(accessToken);
+    }
+
+    @Transactional
+    public void logout(HttpServletRequest request) {
+        // 1. 세션에서 카카오 액세스 토큰 가져오기
+        String kakaoAccessToken = (String) request.getSession().getAttribute("kakaoAccessToken");
+
+        // 2. 카카오 서버 로그아웃 호출
+        kakaoAuthClient.kakaoLogout(kakaoAccessToken);
+
+        // 3. 세션에 저장된 카카오 액세스 토큰 제거
+        request.getSession().invalidate();
+
+        // 4. 클라이언트 JWT 삭제는 프론트에서 처리
+    }
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/common/config/Webconfig.java
+++ b/src/main/java/com/kakaotechcampus/team16be/common/config/Webconfig.java
@@ -1,0 +1,19 @@
+package com.kakaotechcampus.team16be.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class Webconfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // 모든 경로에 대해
+                .allowedOrigins("front-server-address") // 프론트 배포 주소
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // 필요한 HTTP 메서드 허용
+                .allowCredentials(false) // jwt이기 때문에 비허용
+                .allowedHeaders("*") // 모든 헤더 허용
+                .maxAge(3600); // preflight 요청 캐시 시간
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/group/domain/SafetyTag.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/domain/SafetyTag.java
@@ -1,5 +1,7 @@
 package com.kakaotechcampus.team16be.group.domain;
 
 public enum SafetyTag {
-    위험,안전, 주의,
+    DANGER,//위험
+    SAFE,//안전
+    CAUTION;//주의
 }

--- a/src/main/java/com/kakaotechcampus/team16be/user/domain/Role.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/domain/Role.java
@@ -1,6 +1,6 @@
 package com.kakaotechcampus.team16be.user.domain;
 
 public enum Role {
-    user,
-    admin
+    USER,
+    ADMIN
 }

--- a/src/main/java/com/kakaotechcampus/team16be/user/domain/Role.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/domain/Role.java
@@ -1,0 +1,6 @@
+package com.kakaotechcampus.team16be.user.domain;
+
+public enum Role {
+    user,
+    admin
+}

--- a/src/main/java/com/kakaotechcampus/team16be/user/domain/User.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/domain/User.java
@@ -1,0 +1,40 @@
+package com.kakaotechcampus.team16be.user.domain;
+
+import com.kakaotechcampus.team16be.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "kakaoId", length = 64)
+    private String kakaoId;
+
+    @Column(name = "nickname", length = 40)
+    private String nickname;
+
+    @Column(name = "profileImageUrl", length = 512)
+    private String profileImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role")
+    private Role role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "verificationStatus")
+    private VerificationStatus verificationStatus;
+
+    @Column(name = "studentIdImageUrl", length = 512)
+    private String studentIdImageUrl;
+
+    @Column(name = "groupId")
+    private Long groupId;
+
+    @Column(name = "score")
+    private Long score;
+}

--- a/src/main/java/com/kakaotechcampus/team16be/user/domain/User.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/domain/User.java
@@ -16,7 +16,7 @@ public class User extends BaseEntity {
     @Column(name = "kakao_id", unique = true, nullable = false, length = 64)
     private String kakaoId;
 
-    @Column(name = "nickname", unique = true, nullable = false, length = 40)
+    @Column(name = "nickname", unique = true, length = 40)
     private String nickname;
 
     @Column(name = "profile_image_url", length = 512)
@@ -35,4 +35,12 @@ public class User extends BaseEntity {
 
     @Column(name = "score")
     private Long score;
+
+    protected User() {}
+
+    public User(String kakaoId) {
+        this.kakaoId = kakaoId;
+        this.role = Role.user; // 기본 권한
+        this.verificationStatus = VerificationStatus.unverified; // 기본 인증 상태
+    }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/user/domain/User.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/domain/User.java
@@ -6,34 +6,32 @@ import lombok.Getter;
 
 @Entity
 @Getter
+@Table(name = "users")
 public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "kakaoId", length = 64)
+    @Column(name = "kakao_id", unique = true, nullable = false, length = 64)
     private String kakaoId;
 
-    @Column(name = "nickname", length = 40)
+    @Column(name = "nickname", unique = true, nullable = false, length = 40)
     private String nickname;
 
-    @Column(name = "profileImageUrl", length = 512)
+    @Column(name = "profile_image_url", length = 512)
     private String profileImageUrl;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "role")
+    @Column(name = "role", nullable = false)
     private Role role;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "verificationStatus")
+    @Column(name = "verification_status", nullable = false)
     private VerificationStatus verificationStatus;
 
-    @Column(name = "studentIdImageUrl", length = 512)
+    @Column(name = "student_id_image_url", length = 512)
     private String studentIdImageUrl;
-
-    @Column(name = "groupId")
-    private Long groupId;
 
     @Column(name = "score")
     private Long score;

--- a/src/main/java/com/kakaotechcampus/team16be/user/domain/User.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/domain/User.java
@@ -40,7 +40,7 @@ public class User extends BaseEntity {
 
     public User(String kakaoId) {
         this.kakaoId = kakaoId;
-        this.role = Role.user; // 기본 권한
-        this.verificationStatus = VerificationStatus.unverified; // 기본 인증 상태
+        this.role = Role.USER; // 기본 권한
+        this.verificationStatus = VerificationStatus.UNVERIFIED; // 기본 인증 상태
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/user/domain/VerificationStatus.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/domain/VerificationStatus.java
@@ -1,0 +1,7 @@
+package com.kakaotechcampus.team16be.user.domain;
+
+public enum VerificationStatus {
+    unverified,
+    pending,
+    verified
+}

--- a/src/main/java/com/kakaotechcampus/team16be/user/domain/VerificationStatus.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/domain/VerificationStatus.java
@@ -1,7 +1,7 @@
 package com.kakaotechcampus.team16be.user.domain;
 
 public enum VerificationStatus {
-    unverified,
-    pending,
-    verified
+    UNVERIFIED,
+    PENDING,
+    VERIFIED
 }

--- a/src/main/java/com/kakaotechcampus/team16be/user/repository/UserRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.kakaotechcampus.team16be.user.repository;
+
+import com.kakaotechcampus.team16be.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByKakaoId(String kakaoId);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,11 @@ spring.h2.console.path=/h2-console
 # JPA 옵션
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+
+jwt.secret=${JWT_SECRET_KEY}
+kakao.client-id=${KAKAO_CLIENT_ID}
+kakao.redirect-uri=${KAKAO_REDIRECT_URI}
+
+#일시적 통신을 위한 설정
+server.address=0.0.0.0
+server.port=8080

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,15 @@
 spring.application.name=Team16-BE
+
+# H2 데이터베이스 설정
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.username=sa
+spring.datasource.password=
+
+# H2 콘솔 활성화
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+# JPA 옵션
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true


### PR DESCRIPTION
### 관련 이슈
- Closes #5 

---

- [x] 인가코드를 프론트가 넘겨주는 형태로 구현 (비즈앱이 프론트에게 있음)
- [x] 카카오 액세스 토큰 기반 로그인 구현
- [x] 내부 JWT 발급 시 카카오 액세스 토큰 만료시간과 동일하게 설정하여 토큰 일관성 유지
- [x] 서버 JWT 만료 기준으로 로그인 상태 판단
- [x] 카카오 인가 코드로 카카오 액세스 토큰 요청
- [x] 세션에 카카오 액세스 토큰 저장
- [x] 카카오 액세스 토큰으로 kakaoId 조회
- [x] 조회된 kakaoId로 DB 회원 확인, 없으면 신규 User 엔티티 생성 후 저장
- [x] AuthExceptionHandler, KakaoErrorCode, KakaoException, ErrorResponseDto 예외 처리 로직 추가 (서비스 로직에서 발생할 수 있는 예외를 중앙에서 관리하고, 클라이언트에 일관된 응답을 반환하는 구조)

❗ 비즈앱 등록까지 해도 카카오 계정의 이름을 가져오는 건 사업자 등록 후 심사과정이 필요하다해서 실제 이름을 가져오는 로직은 구현에서 제외하였습니다. 
❗ 추가로 카카오 로그인 api는 프론트엔드와의 통신이 완료되었습니다.
❗  환경변수 .env 파일은 노출되면 안되는 파일로 gitignore 하여서 커밋되지 않은 상태이므로 따로 최상위 폴더 아래에 .env 파일을 추가하여 넣어주셔야 합니다.
