### PR TITLE
feat: S3 presigned URL 발급해주는 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/kakaotechcampus/team16be/Team16BeApplication.java
+++ b/src/main/java/com/kakaotechcampus/team16be/Team16BeApplication.java
@@ -19,6 +19,11 @@ public class Team16BeApplication {
         System.setProperty("KAKAO_CLIENT_ID", dotenv.get("KAKAO_CLIENT_ID"));
         System.setProperty("KAKAO_REDIRECT_URI", dotenv.get("KAKAO_REDIRECT_URI"));
 
+        System.setProperty("AWS_ACCESS_KEY_ID", dotenv.get("AWS_ACCESS_KEY_ID"));
+        System.setProperty("AWS_SECRET_ACCESS_KEY", dotenv.get("AWS_SECRET_ACCESS_KEY"));
+        System.setProperty("AWS_REGION", dotenv.get("AWS_REGION"));
+        System.setProperty("AWS_S3_BUCKET", dotenv.get("AWS_S3_BUCKET"));
+
         SpringApplication.run(Team16BeApplication.class, args);
     }
 

--- a/src/main/java/com/kakaotechcampus/team16be/aws/config/S3Config.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.kakaotechcampus.team16be.aws.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client)
+                AmazonS3ClientBuilder.standard()
+                        .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                        .withRegion(region)
+                        .build();
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/aws/controller/ImageController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/controller/ImageController.java
@@ -1,0 +1,29 @@
+package com.kakaotechcampus.team16be.aws.controller;
+
+import com.kakaotechcampus.team16be.aws.dto.ImageUrlDto;
+import com.kakaotechcampus.team16be.aws.dto.IssuePresignedUrlRequest;
+import com.kakaotechcampus.team16be.aws.service.S3UploadPresignedUrlService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/image")
+public class ImageController {
+
+    private final S3UploadPresignedUrlService s3UploadPresignedUrlService;
+
+    public ImageController(S3UploadPresignedUrlService s3UploadPresignedUrlService) {
+        this.s3UploadPresignedUrlService = s3UploadPresignedUrlService;
+    }
+
+    @PostMapping("/presigned")
+    public ResponseEntity<ImageUrlDto> createPresignedUrl(@RequestBody IssuePresignedUrlRequest request) {
+        ImageUrlDto imageUrlDto = s3UploadPresignedUrlService.execute(
+                request.userId(), request.fileExtension(), request.type());
+        return ResponseEntity.ok(imageUrlDto);
+    }
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/aws/domain/ImageFileExtension.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/domain/ImageFileExtension.java
@@ -1,0 +1,18 @@
+package com.kakaotechcampus.team16be.aws.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/***
+ * 지원하는 이미지 파일 확장자 : jpg, png, heic
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ImageFileExtension {
+
+    JPG("jpg"),
+    PNG("png"),
+    HEIC("heic");
+
+    private final String uploadExtension;
+}

--- a/src/main/java/com/kakaotechcampus/team16be/aws/domain/ImageUploadType.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/domain/ImageUploadType.java
@@ -1,0 +1,25 @@
+package com.kakaotechcampus.team16be.aws.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/***
+ * 도메인별 이미지 분류
+ *
+ * 사용자 프로필 사진
+ * 그룹 아이콘
+ * 게시글 사진
+ * 학생 인증 서류
+ *
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ImageUploadType {
+
+    PROFILE("profile"),
+    GROUP_ICON("group-icon"),
+    POST("post"),
+    VERIFICATION("verification");
+
+    private final String type;
+}

--- a/src/main/java/com/kakaotechcampus/team16be/aws/dto/ImageUrlDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/dto/ImageUrlDto.java
@@ -1,0 +1,10 @@
+package com.kakaotechcampus.team16be.aws.dto;
+
+public record ImageUrlDto(
+        String url, //presigned-URL, 클라이언트가 이 URL로 직접 S3에 업로드 가능
+        String fileName //S3 상의 실제 저장 경로, 서버가 나중에 삭제하거나 관리할 때 필요
+) {
+    public static ImageUrlDto of(String url, String fileName) {
+        return new ImageUrlDto(url, fileName);
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/aws/dto/IssuePresignedUrlRequest.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/dto/IssuePresignedUrlRequest.java
@@ -1,0 +1,10 @@
+package com.kakaotechcampus.team16be.aws.dto;
+
+import com.kakaotechcampus.team16be.aws.domain.ImageFileExtension;
+import com.kakaotechcampus.team16be.aws.domain.ImageUploadType;
+
+public record IssuePresignedUrlRequest(
+        Long userId, //누가 업로드 하는지 식별용 (user의 기본키인 userId)
+        ImageFileExtension fileExtension, //확장자
+        ImageUploadType type //업로드 타입
+) {}

--- a/src/main/java/com/kakaotechcampus/team16be/aws/service/S3UploadPresignedUrlService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/service/S3UploadPresignedUrlService.java
@@ -1,0 +1,85 @@
+package com.kakaotechcampus.team16be.aws.service;
+
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.HttpMethod;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.kakaotechcampus.team16be.aws.domain.ImageFileExtension;
+import com.kakaotechcampus.team16be.aws.domain.ImageUploadType;
+import com.kakaotechcampus.team16be.aws.dto.ImageUrlDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.net.URL;
+import java.util.Date;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3UploadPresignedUrlService {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public ImageUrlDto execute(
+            Long userId, ImageFileExtension fileExtension, ImageUploadType type
+    ) {
+        String valueFileExtension = fileExtension.getUploadExtension();
+        String valueType = type.getType();
+        String fileName = createFileName(userId, valueFileExtension, valueType);
+        log.info(fileName);
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                getGeneratePreSignedUrlRequest(bucket, fileName, valueFileExtension);
+        URL url = amazonS3Client.generatePresignedUrl(generatePresignedUrlRequest);
+
+        return ImageUrlDto.of(url.toString(), fileName);
+    }
+
+    private String createFileName(Long userId, String fileExtension, String valueType) {
+        return valueType + "/" + userId + "/" + UUID.randomUUID() + "." + fileExtension;
+    }
+
+    // 업로드용 Pre-Signed URL을 생성하기 때문에, PUT을 지정
+    private GeneratePresignedUrlRequest getGeneratePreSignedUrlRequest(
+            String bucket, String fileName, String fileExtension
+    ) {
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucket, fileName)
+                        .withMethod(HttpMethod.PUT)
+                        .withKey(fileName)
+                        .withContentType("image/" + fileExtension)
+                        .withExpiration(getPreSignedUrlExpiration());
+//        generatePresignedUrlRequest.addRequestParameter(
+//                Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
+        return generatePresignedUrlRequest;
+    }
+
+    // 유효 기간 설정 (1분)
+    private Date getPreSignedUrlExpiration() {
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += 60 * 1000;
+        expiration.setTime(expTimeMillis);
+        return expiration;
+    }
+
+    public void deleteImage(String key) {
+        DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucket, key);
+        try {
+            amazonS3Client.deleteObject(deleteObjectRequest);
+        } catch (AmazonServiceException e) {
+            throw e;
+        } catch (SdkClientException e) {
+            throw e;
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,16 +1,16 @@
 spring.application.name=Team16-BE
 
-# H2 데이터베이스 설정
+# H2 \uB370\uC774\uD130\uBCA0\uC774\uC2A4 \uC124\uC815
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:testdb
 spring.datasource.username=sa
 spring.datasource.password=
 
-# H2 콘솔 활성화
+# H2 \uCF58\uC194 \uD65C\uC131\uD654
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
 
-# JPA 옵션
+# JPA \uC635\uC158
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
@@ -18,6 +18,13 @@ jwt.secret=${JWT_SECRET_KEY}
 kakao.client-id=${KAKAO_CLIENT_ID}
 kakao.redirect-uri=${KAKAO_REDIRECT_URI}
 
-#일시적 통신을 위한 설정
+#\uC77C\uC2DC\uC801 \uD1B5\uC2E0\uC744 \uC704\uD55C \uC124\uC815
 server.address=0.0.0.0
 server.port=8080
+
+#s3 \uC138\uD305
+cloud.aws.region.static=${AWS_REGION}
+cloud.aws.s3.bucket=${AWS_S3_BUCKET}
+cloud.aws.credentials.access-key=${AWS_ACCESS_KEY_ID}
+cloud.aws.credentials.secret-key=${AWS_SECRET_ACCESS_KEY}
+cloud.aws.stack.auto=false


### PR DESCRIPTION
### 관련 이슈 
- close #15 

### 구현 세부 사항
- 클라이언트는 서버에 pre-signed URL을 요청
- 서버에서 S3에 pre-signed URL을 요청
- S3는 pre-sigend URL을 서버에 반환
- 서버는 pre-signed URL을 클라이언트에 반환

### 기타 사항
- presgined-URL 발급은 중복되는 로직이기 때문에 태윤님과 같이 페어프로그래밍 했습니다