### PR TITLE
fix: 카카오 액세스 토큰을 세션에 저장하는 로직 제거 & 그에 따른 리팩토링

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/auth/client/KakaoAuthClient.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/client/KakaoAuthClient.java
@@ -22,7 +22,6 @@ public class KakaoAuthClient {
     // 카카오 API URL 상수
     private static final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
     private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
-    private static final String KAKAO_LOGOUT_URL = "https://kapi.kakao.com/v1/user/logout";
 
     private final KakaoProperties kakaoProperties;
     private final RestTemplate restTemplate;
@@ -126,25 +125,6 @@ public class KakaoAuthClient {
             throw new KakaoException(KakaoErrorCode.USER_INFO_REQUEST_FAILED);
         } catch (ResourceAccessException ex) {
             throw new KakaoException(KakaoErrorCode.CONNECTION_FAILED);
-        }
-    }
-
-
-    public void kakaoLogout(String accessToken) {
-        try {
-            HttpHeaders headers = new HttpHeaders();
-            headers.setBearerAuth(accessToken);
-            HttpEntity<Void> request = new HttpEntity<>(headers);
-
-            restTemplate.exchange(
-                    KAKAO_LOGOUT_URL,
-                    HttpMethod.POST,
-                    request,
-                    String.class
-            );
-        } catch (HttpClientErrorException e) {
-            // 토큰 만료나 인증 실패 등 카카오 오류를 KakaoException으로 변환
-            throw new KakaoException(KakaoErrorCode.LOGOUT_FAILED);
         }
     }
 

--- a/src/main/java/com/kakaotechcampus/team16be/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/controller/AuthController.java
@@ -19,7 +19,7 @@ public class AuthController {
     private final KakaoAuthService kakaoAuthService;
     private final UserService userService;
 
-    @PostMapping("/kakao-login")
+    @GetMapping("/kakao-login")
     public ResponseEntity<KakaoLoginResponse> kakaoLogin(
             @RequestParam("code") String code,
             HttpServletRequest request

--- a/src/main/java/com/kakaotechcampus/team16be/auth/exception/KakaoErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/exception/KakaoErrorCode.java
@@ -10,7 +10,6 @@ public enum KakaoErrorCode {
     TOKEN_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 토큰 요청에 실패했습니다."),
     USER_INFO_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 사용자 정보 요청에 실패했습니다."),
     CONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 서버와의 연결에 실패했습니다."),
-    LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 로그아웃에 실패했습니다."),
 
     // 503 SERVICE_UNAVAILABLE
     SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "카카오 서비스가 일시적으로 불가능합니다. 잠시 후 다시 시도해주세요.");

--- a/src/main/java/com/kakaotechcampus/team16be/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/jwt/JwtProvider.java
@@ -21,6 +21,9 @@ public class JwtProvider {
     @Value("${jwt.secret}")
     private String secret;
 
+    @Value("${jwt.access-token-expiration}")
+    private int accessTokenExpiration;
+
     private SecretKey secretKey;
 
     @PostConstruct
@@ -32,12 +35,11 @@ public class JwtProvider {
     /**
      * JWT 토큰 생성
      * @param user 토큰에 담을 User 정보
-     * @param expiresIn 토큰 만료 시간(초)
      * @return JWT 문자열
      */
-    public String createToken(User user, int expiresIn) {
+    public String createToken(User user) {
         Date now = new Date();
-        Date expiryDate = new Date(now.getTime() + expiresIn * 1000L);
+        Date expiryDate = new Date(now.getTime() + accessTokenExpiration  * 1000L);
 
         return Jwts.builder()
                 .setSubject(String.valueOf(user.getId()))

--- a/src/main/java/com/kakaotechcampus/team16be/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/service/KakaoAuthService.java
@@ -38,27 +38,15 @@ public class KakaoAuthService {
                     return userRepository.save(newUser);
                 });
 
-        // 4. kakaoAccessToken을 세션에 저장
-        request.getSession().setAttribute("kakaoAccessToken", kakaoAccessToken);
-
-        // 5. JWT 발급 (만료시간은 카카오액세스토큰이랑 똑같이 설정함)
-        String accessToken = jwtProvider.createToken(user, kakaoTokenResponse.expiresIn());
+        // 5. JWT 발급
+        String accessToken = jwtProvider.createToken(user);
 
         return new KakaoLoginResponse(accessToken);
     }
 
     @Transactional
     public void logout(HttpServletRequest request) {
-        // 1. 세션에서 카카오 액세스 토큰 가져오기
-        String kakaoAccessToken = (String) request.getSession().getAttribute("kakaoAccessToken");
 
-        // 2. 카카오 서버 로그아웃 호출
-        kakaoAuthClient.kakaoLogout(kakaoAccessToken);
-
-        // 3. 세션에 저장된 카카오 액세스 토큰 제거
-        request.getSession().invalidate();
-
-        // 4. 클라이언트 JWT 삭제는 프론트에서 처리
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,11 @@ spring.h2.console.path=/h2-console
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
+# jwt
 jwt.secret=${JWT_SECRET_KEY}
+jwt.access-token-expiration=${JWT_ACCESS_TOKEN_EXPIRATION}
+
+# kakao
 kakao.client-id=${KAKAO_CLIENT_ID}
 kakao.redirect-uri=${KAKAO_REDIRECT_URI}
 


### PR DESCRIPTION
### 관련 이슈
- #25 

### 상세 내용
- 기존에 카카오 액세스 토큰과 만료시간을 동일하게 설정하는 로직을 제거하였고, jwt accessToken 만료시간을 따로 설정해주었습니다.
- 카카오 액세스 토큰을 세션에 저장하는 로직을 제거함에 따라 로그아웃 로직을 제거하였습니다. 이는 프론트에서 jwt를 단순 삭제하는 것으로 해결될 일이지만 추후에 블랙리스트를 적용해보려고 해서 빈 로직을 남겨두었습니다.

### 추가 사항
- 인가코드 받는 방식을 server-to-server로 변경함에 따라 로그인 api를 Post에서 Get으로 수정하였습니다.