### PR TITLE
fix: @LoginUser 타입 변경 및 loginCheckInterceptor 검증 범위 수정

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.kakaotechcampus.team16be.auth.dto.StudentVerificationStatusResponse;
 import com.kakaotechcampus.team16be.auth.dto.UpdateStudentIdImageRequest;
 import com.kakaotechcampus.team16be.auth.service.KakaoAuthService;
 import com.kakaotechcampus.team16be.common.annotation.LoginUser;
+import com.kakaotechcampus.team16be.user.domain.User;
 import com.kakaotechcampus.team16be.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -36,18 +37,18 @@ public class AuthController {
 
     @PutMapping("/student-verification")
     public ResponseEntity<Void> updateStudentIdImage(
-            @LoginUser Long userId,
+            @LoginUser User user,
             @RequestBody UpdateStudentIdImageRequest request
     ) {
-        userService.updateStudentIdImage(userId, request);
+        userService.updateStudentIdImage(user.getId(), request);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/student-verification/status")
     public ResponseEntity<StudentVerificationStatusResponse> getVerificationStatus(
-            @LoginUser Long userId
+            @LoginUser User user
     ) {
-        StudentVerificationStatusResponse response = userService.getVerificationStatus(userId);
+        StudentVerificationStatusResponse response = userService.getVerificationStatus(user.getId());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/aws/controller/ImageController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/controller/ImageController.java
@@ -4,6 +4,7 @@ import com.kakaotechcampus.team16be.aws.dto.ImageUrlDto;
 import com.kakaotechcampus.team16be.aws.dto.IssuePresignedUrlRequest;
 import com.kakaotechcampus.team16be.aws.service.S3UploadPresignedUrlService;
 import com.kakaotechcampus.team16be.common.annotation.LoginUser;
+import com.kakaotechcampus.team16be.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,11 +21,11 @@ public class ImageController {
 
     @PostMapping("/presigned")
     public ResponseEntity<ImageUrlDto> createPresignedUrl(
-            @LoginUser Long userId,
+            @LoginUser User user,
             @RequestBody IssuePresignedUrlRequest request
     ) {
         ImageUrlDto imageUrlDto = s3UploadPresignedUrlService.execute(
-                userId, request.fileExtension(), request.type());
+                user.getId(), request.fileExtension(), request.type());
         return ResponseEntity.ok(imageUrlDto);
     }
 

--- a/src/main/java/com/kakaotechcampus/team16be/common/config/Webconfig.java
+++ b/src/main/java/com/kakaotechcampus/team16be/common/config/Webconfig.java
@@ -33,7 +33,10 @@ public class Webconfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loginCheckInterceptor)
                 .addPathPatterns("/api/**") // JWT 적용할 경로
-                .excludePathPatterns("/api/auth/**"); //인가 부분은 제외
+                .excludePathPatterns(
+                        "/api/auth/kakao-login",
+                        "/api/auth/kakao-logout"
+                ); //로그인 로그아웃은 제외
 
     }
 


### PR DESCRIPTION
### 관련 이슈
- close #27 

### 수정 사항
- @LoginUser 파라미터를 Long -> User로 변경하여 resolver와 호환되도록 수정하였습니다. (AuthController, ImageController 부분만 수정했으므로 다른 컨트롤러들도 수정해줘야할 필요가 있습니다)
- loginCheckInterceptor에서 로그인/로그아웃 API 제외하고 모든 요청 인증 체크하도록 수정하였습니다.
