### PR TITLE
feat: 증빙서류(학생증) 조회하는 api 구현

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.kakaotechcampus.team16be.auth.controller;
 
 import com.kakaotechcampus.team16be.auth.dto.KakaoLoginResponse;
+import com.kakaotechcampus.team16be.auth.dto.StudentIdImageResponse;
 import com.kakaotechcampus.team16be.auth.dto.StudentVerificationStatusResponse;
 import com.kakaotechcampus.team16be.auth.dto.UpdateStudentIdImageRequest;
 import com.kakaotechcampus.team16be.auth.service.KakaoAuthService;
@@ -42,6 +43,14 @@ public class AuthController {
     ) {
         userService.updateStudentIdImage(user.getId(), request);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/student-verification")
+    public ResponseEntity<StudentIdImageResponse> getStudentIdImage(
+            @LoginUser User user
+    ) {
+        String imageUrl = userService.getStudentIdImageUrl(user);
+        return ResponseEntity.ok(new StudentIdImageResponse(imageUrl));
     }
 
     @GetMapping("/student-verification/status")

--- a/src/main/java/com/kakaotechcampus/team16be/auth/dto/StudentIdImageResponse.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/dto/StudentIdImageResponse.java
@@ -1,0 +1,5 @@
+package com.kakaotechcampus.team16be.auth.dto;
+
+public record StudentIdImageResponse(
+        String imageUrl
+) {}

--- a/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.kakaotechcampus.team16be.user.service;
 import com.kakaotechcampus.team16be.auth.dto.StudentVerificationStatusResponse;
 import com.kakaotechcampus.team16be.auth.dto.UpdateStudentIdImageRequest;
 import com.kakaotechcampus.team16be.aws.domain.ImageUploadType;
+import com.kakaotechcampus.team16be.aws.service.S3UploadPresignedUrlService;
 import com.kakaotechcampus.team16be.user.domain.User;
 import com.kakaotechcampus.team16be.user.exception.UserErrorCode;
 import com.kakaotechcampus.team16be.user.exception.UserException;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final S3UploadPresignedUrlService s3UploadPresignedUrlService;
 
     @Transactional
     public void updateStudentIdImage(Long userId, UpdateStudentIdImageRequest request) {
@@ -39,5 +41,11 @@ public class UserService {
                 user.getVerificationStatus(),
                 null
         );
+    }
+
+    @Transactional(readOnly = true)
+    public String getStudentIdImageUrl(User user) {
+        String fileName = user.getStudentIdImageUrl();
+        return s3UploadPresignedUrlService.getPublicUrl(fileName);
     }
 }


### PR DESCRIPTION
### 관련 이슈
- close #29 

### 설명
User엔티티의 DB에 저장된 학생증 이미지는 S3 저장 경로를 나타냅니다. 이를 이용해 server to S3 방식으로 이미지가 보여지는 url을 받아와서 반환해줍니다.