### PR TITLE
feat: 닉네임 설정,조회,변경 api 구현

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/user/controller/UserController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/controller/UserController.java
@@ -3,6 +3,8 @@ package com.kakaotechcampus.team16be.user.controller;
 import com.kakaotechcampus.team16be.common.annotation.LoginUser;
 import com.kakaotechcampus.team16be.user.domain.User;
 import com.kakaotechcampus.team16be.user.dto.UpdateProfileImageRequest;
+import com.kakaotechcampus.team16be.user.dto.UserNicknameRequest;
+import com.kakaotechcampus.team16be.user.dto.UserNicknameResponse;
 import com.kakaotechcampus.team16be.user.dto.UserProfileImageResponse;
 import com.kakaotechcampus.team16be.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -52,12 +54,44 @@ public class UserController {
         return ResponseEntity.ok(new UserProfileImageResponse(imageUrl));
     }
 
+    /**
+     * 프로필 이미지 삭제
+     */
     @DeleteMapping("/profile-image")
     public ResponseEntity<Void> deleteProfileImage(
             @LoginUser User user
     ) {
         userService.deleteProfileImage(user.getId());
         return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    /** 닉네임 최초 등록 */
+    @PostMapping("/nickname")
+    public ResponseEntity<String> createNickname(
+            @LoginUser User user,
+            @RequestBody UserNicknameRequest request
+    ) {
+        userService.createNickname(user, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body("닉네임이 설정되었습니다.");
+    }
+
+    /** 닉네임 조회 */
+    @GetMapping("/nickname")
+    public ResponseEntity<UserNicknameResponse> getNickname(
+            @LoginUser User user
+    ) {
+        UserNicknameResponse response = userService.getNickname(user);
+        return ResponseEntity.ok(response);
+    }
+
+    /** 닉네임 수정 */
+    @PutMapping("/nickname")
+    public ResponseEntity<String> updateNickname(
+            @LoginUser User user,
+            @RequestBody UserNicknameRequest request
+    ) {
+        userService.updateNickname(user, request);
+        return ResponseEntity.ok("닉네임이 변경되었습니다.");
     }
 
 }

--- a/src/main/java/com/kakaotechcampus/team16be/user/domain/User.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/domain/User.java
@@ -55,4 +55,8 @@ public class User extends BaseEntity {
     public void updateProfileImageUrl(String fileName) {
         this.profileImageUrl = fileName;
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/user/dto/UserNicknameRequest.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/dto/UserNicknameRequest.java
@@ -1,0 +1,6 @@
+package com.kakaotechcampus.team16be.user.dto;
+
+public record UserNicknameRequest(
+        String nickname
+) {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/user/dto/UserNicknameResponse.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/dto/UserNicknameResponse.java
@@ -1,0 +1,9 @@
+package com.kakaotechcampus.team16be.user.dto;
+
+public record UserNicknameResponse(
+        String nickname
+) {
+    public static UserNicknameResponse from(String nickname) {
+        return new UserNicknameResponse(nickname);
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
@@ -5,6 +5,8 @@ import com.kakaotechcampus.team16be.auth.dto.UpdateStudentIdImageRequest;
 import com.kakaotechcampus.team16be.aws.domain.ImageUploadType;
 import com.kakaotechcampus.team16be.aws.service.S3UploadPresignedUrlService;
 import com.kakaotechcampus.team16be.user.domain.User;
+import com.kakaotechcampus.team16be.user.dto.UserNicknameRequest;
+import com.kakaotechcampus.team16be.user.dto.UserNicknameResponse;
 import com.kakaotechcampus.team16be.user.exception.UserErrorCode;
 import com.kakaotechcampus.team16be.user.exception.UserException;
 import com.kakaotechcampus.team16be.user.repository.UserRepository;
@@ -89,9 +91,27 @@ public class UserService {
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
     }
 
+    @Transactional
     public void deleteProfileImage(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
         user.updateProfileImageUrl(null);
+    }
+
+    @Transactional
+    public void createNickname(User user, UserNicknameRequest request) {
+        user.updateNickname(request.nickname());
+        userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public UserNicknameResponse getNickname(User user) {
+        return UserNicknameResponse.from(user.getNickname());
+    }
+
+    @Transactional
+    public void updateNickname(User user, UserNicknameRequest request) {
+        user.updateNickname(request.nickname());
+        userRepository.save(user);
     }
 }


### PR DESCRIPTION
### 관련이슈
- close #34 

### 구현사항 
- POST 닉네임을 설정합니다.
- GET 닉네임을 조회합니다.
- PUT 닉네임을 변경합니다.

### 참고사항
- restful함을 위해 POST,GET 로직은 같으나 합치지않고 api를 분리합니다.
- POST, PUT 로직에서 jpa의 변경감지에 의존하지 않고 save를 명시해주었습니다.