### PR TITLE
fix: 프론트 배포 주소가 잘못된 부분 수정

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/common/config/Webconfig.java
+++ b/src/main/java/com/kakaotechcampus/team16be/common/config/Webconfig.java
@@ -23,7 +23,7 @@ public class Webconfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**") // 모든 경로에 대해
-                .allowedOrigins("https://team16-fe-95ue.vercel.app/login") // 프론트 배포 주소
+                .allowedOrigins("https://team16-fe-95ue.vercel.app") // 프론트 배포 주소
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // 필요한 HTTP 메서드 허용
                 .allowCredentials(false) // jwt이기 때문에 비허용
                 .allowedHeaders("*") // 모든 헤더 허용


### PR DESCRIPTION
### 관련 이슈
-close #47 

### 작업 내용
- 기존의 corsMapping 부분에 프론트 주소가 잘못 기입된 부분을 수정했습니다.

