### PR TITLE
fix: UpdateStudentIdImageRequest의 type 필드 제거

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/auth/dto/UpdateStudentIdImageRequest.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/dto/UpdateStudentIdImageRequest.java
@@ -3,7 +3,6 @@ package com.kakaotechcampus.team16be.auth.dto;
 import com.kakaotechcampus.team16be.aws.domain.ImageUploadType;
 
 public record UpdateStudentIdImageRequest(
-        String fileName,
-        ImageUploadType type
+        String fileName
 ) {
 }

--- a/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
@@ -26,10 +26,8 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
-        if (request.type() == ImageUploadType.VERIFICATION) {
-            user.updateStudentIdImageUrl(request.fileName());
-            user.updateVerificationStatusPending();
-        }
+        user.updateStudentIdImageUrl(request.fileName());
+        user.updateVerificationStatusPending();
 
         userRepository.save(user);
     }


### PR DESCRIPTION
##before
```
{
    "fileName": "users/1234/학생증_20250908.png",
    "type": "VERIFICATION"
}
```

##after
```
{
    "fileName": "users/1234/학생증_20250908.png"
}
```
## 설명
현재 학생증 업로드 API(/student-verification)에서 요청 DTO가 아래와 같이 두 개의 필드를 받고 있습니다.

그러나

API가 목적별로 분리되어 있어, type 필드는 DB에 저장되지 않고 실제 서비스 로직에서도 사용되지 않습니다.
type 필드는 프론트에서 업로드 목적을 구분하기 위해 넣었던 안전장치였지만, 현재는 불필요한 상태입니다.

따라서 DTO의 type필드를 제거하였습니다.
