### PR TITLE
feat: 현재 develop 브랜치의 모든 controller에 swagger 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-    //.env 읽어서 환경설정변수를 주입해주는 의존성
-    implementation 'io.github.cdimascio:dotenv-java:3.0.0'
+    //swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 }
 

--- a/src/main/java/com/kakaotechcampus/team16be/auth/controller/AdminAuthController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/controller/AdminAuthController.java
@@ -4,6 +4,8 @@ import com.kakaotechcampus.team16be.auth.dto.StudentIdImageResponse;
 import com.kakaotechcampus.team16be.common.annotation.LoginUser;
 import com.kakaotechcampus.team16be.user.domain.User;
 import com.kakaotechcampus.team16be.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,9 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/admin/auth")
 @RequiredArgsConstructor
+@Tag(name = "인증 인가 관련 API", description = "어드민용 인증 인가 API")
 public class AdminAuthController {
     private final UserService userService;
 
+    @Operation(summary = "증빙서류(학생증) 이미지 조회", description = "유저의 증빙서류(학생증) 이미지를 반환합니다.")
     @GetMapping("/student-verification")
     public ResponseEntity<StudentIdImageResponse> getStudentIdImage(
             @LoginUser User adminUser

--- a/src/main/java/com/kakaotechcampus/team16be/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/controller/AuthController.java
@@ -7,6 +7,8 @@ import com.kakaotechcampus.team16be.auth.service.KakaoAuthService;
 import com.kakaotechcampus.team16be.common.annotation.LoginUser;
 import com.kakaotechcampus.team16be.user.domain.User;
 import com.kakaotechcampus.team16be.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,11 +17,13 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Tag(name = "인증 인가 관련 API", description = "인증 인가 API")
 public class AuthController {
 
     private final KakaoAuthService kakaoAuthService;
     private final UserService userService;
 
+    @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 받아 로그인 처리 후 토큰을 반환합니다.")
     @GetMapping("/kakao-login")
     public ResponseEntity<KakaoLoginResponse> kakaoLogin(
             @RequestParam("code") String code,
@@ -29,12 +33,14 @@ public class AuthController {
         return ResponseEntity.ok(kakaoLoginResponse);
     }
 
+    @Operation(summary = "카카오 로그아웃", description = "현재는 액세스 토큰만 사용하고 있어서 별 거 없음. 추후 리프레시 토큰 생기면 블랙리스트 처리해줄 예정입니다.")
     @PostMapping("/kakao-logout")
     public ResponseEntity<Void> logout(HttpServletRequest request) {
         kakaoAuthService.logout(request);
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "증빙서류(학생증) 업로드 완료시", description = "증빙서류(학생증) 이미지를 해당 유저의 DB에 저장합니다.")
     @PutMapping("/student-verification")
     public ResponseEntity<Void> updateStudentIdImage(
             @LoginUser User user,
@@ -44,6 +50,7 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "증빙서류(학생증) 인증 상태 조회", description = "유저의 증빙서류(학생증) 인증 상태를 반환합니다.")
     @GetMapping("/student-verification/status")
     public ResponseEntity<StudentVerificationStatusResponse> getVerificationStatus(
             @LoginUser User user

--- a/src/main/java/com/kakaotechcampus/team16be/aws/controller/ImageController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/controller/ImageController.java
@@ -5,6 +5,8 @@ import com.kakaotechcampus.team16be.aws.dto.IssuePresignedUrlRequest;
 import com.kakaotechcampus.team16be.aws.service.S3UploadPresignedUrlService;
 import com.kakaotechcampus.team16be.common.annotation.LoginUser;
 import com.kakaotechcampus.team16be.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,10 +17,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/image")
 @RequiredArgsConstructor
+@Tag(name = "이미지 공통 API", description = "이미지 관련 공통 API")
 public class ImageController {
 
     private final S3UploadPresignedUrlService s3UploadPresignedUrlService;
 
+    @Operation(summary = "S3 이미지 주소 요청", description = "이미지 업로드할 presigned-url을 반환합니다.")
     @PostMapping("/presigned")
     public ResponseEntity<ImageUrlDto> createPresignedUrl(
             @LoginUser User user,

--- a/src/main/java/com/kakaotechcampus/team16be/comment/controller/CommentController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/controller/CommentController.java
@@ -6,6 +6,8 @@ import com.kakaotechcampus.team16be.comment.dto.GetCommentsResponse;
 import com.kakaotechcampus.team16be.comment.service.CommentService;
 import com.kakaotechcampus.team16be.common.annotation.LoginUser;
 import com.kakaotechcampus.team16be.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,10 +16,12 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "댓글 API", description = "댓글 관련 API")
 public class CommentController {
 
     private final CommentService commentService;
 
+    @Operation(summary = "댓글 조회", description = "특정 게시글의 댓글 목록을 조회합니다. 부모 댓글 ID를 지정하면 대댓글 조회도 가능합니다.")
     @GetMapping("/groups/{groupId}/posts/{postId}/comments")
     public ResponseEntity<GetCommentsResponse> getComments(@PathVariable Long postId,
                                                          @RequestParam(required = false) Long parentId,
@@ -26,6 +30,7 @@ public class CommentController {
         return ResponseEntity.ok(commentService.getComments(postId, parentId, cursor, limit));
     }
 
+    @Operation(summary = "댓글 작성", description = "특정 게시글에 댓글을 작성합니다.")
     @PostMapping("/groups/{groupId}/posts/{postId}/comments")
     public ResponseEntity<CommentResponse> createComment(@PathVariable Long postId,
                                                        @RequestBody CommentRequest request,
@@ -33,12 +38,14 @@ public class CommentController {
         return ResponseEntity.status(HttpStatus.CREATED).body(commentService.createComment(postId, user.getId(), request));
     }
 
+    @Operation(summary = "댓글 수정", description = "작성한 댓글을 수정합니다.")
     @PatchMapping("/groups/{groupId}/posts/{postId}/comments/{commentId}")
     public ResponseEntity<CommentResponse> updateComment(@PathVariable Long commentId, 
                                                        @RequestBody CommentRequest request) {
         return ResponseEntity.ok(commentService.updateComment(commentId, request));
     }
 
+    @Operation(summary = "댓글 삭제", description = "작성한 댓글을 삭제합니다.")
     @DeleteMapping("/groups/{groupId}/posts/{postId}/comments/{commentId}")
     public ResponseEntity<Void> deleteComment(@PathVariable Long commentId) {
         commentService.deleteComment(commentId);

--- a/src/main/java/com/kakaotechcampus/team16be/common/config/Webconfig.java
+++ b/src/main/java/com/kakaotechcampus/team16be/common/config/Webconfig.java
@@ -37,7 +37,7 @@ public class Webconfig implements WebMvcConfigurer {
                 .addPathPatterns("/api/**") // JWT 적용할 경로
                 .excludePathPatterns(
                         "/api/auth/kakao-login"
-                ); //로그인 로그아웃은 제외
+                );
 
         registry.addInterceptor(adminCheckInterceptor)
                 .addPathPatterns("/api/admin/**"); // 관리자만 접근

--- a/src/main/java/com/kakaotechcampus/team16be/groundrule/GroundRuleController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groundrule/GroundRuleController.java
@@ -3,6 +3,8 @@ package com.kakaotechcampus.team16be.groundrule;
 import com.kakaotechcampus.team16be.groundrule.dto.GroundRuleRequestDto;
 import com.kakaotechcampus.team16be.groundrule.dto.GroundRuleResponseDto;
 import com.kakaotechcampus.team16be.groundrule.service.GroundRuleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,10 +20,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/groups")
 @RequiredArgsConstructor
+@Tag(name = "그라운드룰 API", description = "그라운드룰 관련 API")
 public class GroundRuleController {
 
   private final GroundRuleService groundRuleService;
 
+  @Operation(summary = "그라운드룰 등록", description = "특정 모임에 새로운 그라운드룰을 등록합니다.")
   @PostMapping("/{groupId}/rule")
   public ResponseEntity<GroundRuleResponseDto> addGroundRule(
       @PathVariable Long groupId,
@@ -30,6 +34,7 @@ public class GroundRuleController {
                          .body(groundRuleService.saveGroundRule(groupId, groundRuleRequestDto));
   }
 
+  @Operation(summary = "그라운드룰 수정", description = "특정 모임의 기존 그라운드룰을 수정합니다.")
   @PutMapping("/{groupId}/rule")
   public ResponseEntity<GroundRuleResponseDto> updateGroundRule(
       @PathVariable Long groupId,
@@ -37,11 +42,13 @@ public class GroundRuleController {
     return ResponseEntity.ok(groundRuleService.updateGroundRule(groupId, groundRuleRequestDto));
   }
 
+  @Operation(summary = "그라운드룰 조회", description = "특정 모임의 그라운드룰을 조회합니다.")
   @GetMapping("/{groupId}/rule")
   public ResponseEntity<GroundRuleResponseDto> getGroundRule(@PathVariable Long groupId) {
     return ResponseEntity.ok(groundRuleService.getGroundRule(groupId));
   }
 
+  @Operation(summary = "그라운드룰 삭제", description = "특정 모임의 그라운드룰을 삭제합니다.")
   @DeleteMapping("/{groupId}/rule")
   public ResponseEntity<Void> deleteGroundRule(@PathVariable Long groupId) {
     groundRuleService.deleteGroundRule(groupId);

--- a/src/main/java/com/kakaotechcampus/team16be/group/controller/GroupController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/controller/GroupController.java
@@ -6,6 +6,8 @@ import com.kakaotechcampus.team16be.group.domain.Group;
 import com.kakaotechcampus.team16be.group.dto.*;
 import com.kakaotechcampus.team16be.group.service.GroupService;
 import com.kakaotechcampus.team16be.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,33 +19,39 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/groups")
 @RequiredArgsConstructor
+@Tag(name = "모임 API", description = "모임 관련 API")
 public class GroupController {
 
     private final GroupService groupService;
 
+    @Operation(summary = "모임 생성", description = "새로운 모임을 생성합니다.")
     @PostMapping
     public ResponseEntity<ResponseCreateGroupDto> createGroup(@LoginUser User user, @Valid @RequestBody CreateGroupDto createGroupDto) {
         Group group = groupService.createGroup(user, createGroupDto);
         return ResponseEntity.ok(ResponseCreateGroupDto.from(group));
     }
 
+    @Operation(summary = "모임 목록 조회", description = "모든 모임 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<List<ResponseGroupListDto>> getAllGroups() {
         List<ResponseGroupListDto> result = groupService.getAllGroups();
         return ResponseEntity.ok(result);
     }
 
+    @Operation(summary = "모임 상세 조회", description = "특정 모임의 상세 정보를 조회합니다.")
     @GetMapping("/{groupId}")
     public ResponseEntity<ResponseSingleGroupDto> getGroup(@PathVariable("groupId") Long groupId) {
         return ResponseEntity.ok(groupService.getGroup(groupId));
     }
 
+    @Operation(summary = "모임 삭제", description = "특정 모임을 삭제합니다.")
     @DeleteMapping("/{groupId}")
     public ResponseEntity<ResponseGroupDto> deleteGroup(@LoginUser User user,@PathVariable("groupId") Long groupId) {
         groupService.deleteGroup(user,groupId);
         return ResponseEntity.ok(ResponseGroupDto.success(HttpStatus.OK, "모임이 성공적으로 삭제되었습니다."));
     }
 
+    @Operation(summary = "모임 수정", description = "특정 모임의 정보를 수정합니다.")
     @PutMapping("/{groupId}")
     public ResponseEntity<ResponseUpdateGroupDto> updateGroup(@LoginUser User user, @PathVariable("groupId") Long groupId, @Valid @RequestBody UpdateGroupDto updateGroupDto) {
         Group group = groupService.updateGroup(user, groupId, updateGroupDto);

--- a/src/main/java/com/kakaotechcampus/team16be/post/controller/PostController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/post/controller/PostController.java
@@ -7,6 +7,8 @@ import com.kakaotechcampus.team16be.post.dto.PostRequest;
 import com.kakaotechcampus.team16be.post.dto.PostResponse;
 import com.kakaotechcampus.team16be.post.service.PostService;
 import com.kakaotechcampus.team16be.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,10 +17,12 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "게시글 API", description = "게시글 관련 API")
 public class PostController {
 
     private final PostService postService;
 
+    @Operation(summary = "게시글 목록 조회", description = "그룹 내 게시글 목록을 조회합니다.")
     @GetMapping("/groups/{groupId}/posts")
     public ResponseEntity<GetPostsResponse> getPosts(@PathVariable Long groupId,
                                                      @RequestParam(required = false) Long cursor,
@@ -27,6 +31,7 @@ public class PostController {
         return ResponseEntity.ok(postService.getPosts(groupId, cursor, limit, search));
     }
 
+    @Operation(summary = "게시글 생성", description = "그룹 내 새로운 게시글을 작성합니다.")
     @PostMapping("/groups/{groupId}/posts")
     public ResponseEntity<PostResponse> createPost(@PathVariable Long groupId, 
                                                        @RequestBody PostRequest request, 
@@ -34,6 +39,7 @@ public class PostController {
         return ResponseEntity.status(HttpStatus.CREATED).body(postService.createPost(groupId, user.getId(), request));
     }
 
+    @Operation(summary = "게시글 수정", description = "기존 게시글을 수정합니다.")
     @PatchMapping("/groups/{groupId}/posts/{postId}")
     public ResponseEntity<PostResponse> updatePost(@PathVariable Long groupId, 
                                                        @PathVariable Long postId, 
@@ -41,6 +47,7 @@ public class PostController {
         return ResponseEntity.ok(postService.updatePost(postId, request));
     }
 
+    @Operation(summary = "게시글 삭제", description = "그룹 내 특정 게시글을 삭제합니다.")
     @DeleteMapping("/groups/{groupId}/posts/{postId}")
     public ResponseEntity<Void> deletePost(@PathVariable Long groupId, 
                                                    @PathVariable Long postId) {
@@ -48,6 +55,7 @@ public class PostController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "게시글 좋아요", description = "게시글에 좋아요를 추가합니다.")
     @PostMapping("/groups/{groupId}/posts/{postId}/likes")
     public ResponseEntity<PostLikeResponse> likePost(@PathVariable Long groupId, 
                                                      @PathVariable Long postId, 
@@ -55,6 +63,7 @@ public class PostController {
         return ResponseEntity.ok(postService.likePost(postId, user.getId()));
     }
 
+    @Operation(summary = "게시글 좋아요 취소", description = "게시글에 대한 좋아요를 취소합니다.")
     @DeleteMapping("/groups/{groupId}/posts/{postId}/likes")
     public ResponseEntity<PostLikeResponse> unlikePost(@PathVariable Long groupId, 
                                                        @PathVariable Long postId, 

--- a/src/main/java/com/kakaotechcampus/team16be/report/controller/AdminReportController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/report/controller/AdminReportController.java
@@ -6,6 +6,9 @@ import com.kakaotechcampus.team16be.report.dto.ReportResponseDto;
 import com.kakaotechcampus.team16be.report.service.ReportService;
 import com.kakaotechcampus.team16be.user.domain.User;
 import java.util.List;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,11 +22,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/admin/reports")
 @RequiredArgsConstructor
+@Tag(name = "신고 관련 API", description = "어드민용 신고 관리 API")
 public class AdminReportController {
 
   private final ReportService reportService;
 
   // 신고 기능의 R&U&D는 관리자만 접근할 수 있게끔 유도
+  @Operation(summary = "신고 처리", description = "들어온 신고의 상태를 변경합니다. (신고 처리)")
   @PatchMapping("/{reportId}")
   public ResponseEntity<ReportResponseDto> resolveReport(
       @PathVariable Long reportId,
@@ -33,11 +38,13 @@ public class AdminReportController {
     return ResponseEntity.ok(reportService.resolveReport(reportId, adminUser, reportResolveRequestDto));
   }
 
+  @Operation(summary = "모든 신고 조회", description = "모든 신고 목록을 조회합니다.")
   @GetMapping
   public ResponseEntity<List<ReportResponseDto>> getAllReports(@LoginUser User adminUser){
     return ResponseEntity.ok(reportService.getAllReports());
   }
 
+  @Operation(summary = "특정 신고 조회", description = "단일 신고 내용을 조회합니다.")
   @GetMapping("/{reportId}")
   public ResponseEntity<ReportResponseDto> getReport(
       @PathVariable Long reportId,
@@ -46,6 +53,7 @@ public class AdminReportController {
     return ResponseEntity.ok(reportService.getReport(reportId));
   }
 
+  @Operation(summary = "신고 삭제", description = "특정 신고를 삭제합니다.")
   @DeleteMapping("/{reportId}")
   public ResponseEntity<Void> deleteReport(
       @PathVariable Long reportId,

--- a/src/main/java/com/kakaotechcampus/team16be/report/controller/UserReportController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/report/controller/UserReportController.java
@@ -6,6 +6,8 @@ import com.kakaotechcampus.team16be.report.dto.ReportRequestDto;
 import com.kakaotechcampus.team16be.report.dto.ReportResponseDto;
 import com.kakaotechcampus.team16be.report.service.ReportService;
 import com.kakaotechcampus.team16be.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,11 +20,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/reports")
 @RequiredArgsConstructor
+@Tag(name = "신고 관련 API", description = "일반 유저용 신고 관련 API")
 public class UserReportController {
 
   private final ReportService reportService;
 
-
+  @Operation(summary = "신고 생성", description = "사용자가 특정 대상(모임, 게시글, 댓글)에 대해 신고를 생성합니다.")
   @PostMapping("/{targetType}/{targetId}")
   public ResponseEntity<ReportResponseDto> createReport(
       @LoginUser User reporter,

--- a/src/main/java/com/kakaotechcampus/team16be/user/controller/UserController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/controller/UserController.java
@@ -7,6 +7,8 @@ import com.kakaotechcampus.team16be.user.dto.UserNicknameRequest;
 import com.kakaotechcampus.team16be.user.dto.UserNicknameResponse;
 import com.kakaotechcampus.team16be.user.dto.UserProfileImageResponse;
 import com.kakaotechcampus.team16be.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,13 +17,12 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
+@Tag(name = "유저 관련 API", description = "마이페이지 등에 쓰이는 유저 관련 API들")
 public class UserController {
 
     private final UserService userService;
 
-    /**
-     * 프로필 이미지 설정 (최초 등록)
-     */
+    @Operation(summary = "프로필 이미지 등록", description = "사용자의 프로필 이미지를 최초 등록합니다.")
     @PostMapping("/profile-image")
     public ResponseEntity<Void> createProfileImage(
             @LoginUser User user,
@@ -31,9 +32,7 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    /**
-     * 프로필 이미지 변경
-     */
+    @Operation(summary = "프로필 이미지 변경", description = "사용자의 기존 프로필 이미지를 새 이미지로 변경합니다.")
     @PutMapping("/profile-image")
     public ResponseEntity<Void> updateProfileImage(
             @LoginUser User user,
@@ -43,9 +42,7 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    /**
-     * 프로필 이미지 조회
-     */
+    @Operation(summary = "프로필 이미지 조회", description = "사용자의 현재 프로필 이미지를 조회합니다.")
     @GetMapping("/profile-image")
     public ResponseEntity<UserProfileImageResponse> getProfileImage(
             @LoginUser User user
@@ -54,9 +51,7 @@ public class UserController {
         return ResponseEntity.ok(new UserProfileImageResponse(imageUrl));
     }
 
-    /**
-     * 프로필 이미지 삭제
-     */
+    @Operation(summary = "프로필 이미지 삭제", description = "사용자의 프로필 이미지를 삭제합니다.")
     @DeleteMapping("/profile-image")
     public ResponseEntity<Void> deleteProfileImage(
             @LoginUser User user
@@ -65,7 +60,7 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    /** 닉네임 최초 등록 */
+    @Operation(summary = "닉네임 등록", description = "사용자의 닉네임을 최초 등록합니다.")
     @PostMapping("/nickname")
     public ResponseEntity<String> createNickname(
             @LoginUser User user,
@@ -75,7 +70,7 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.CREATED).body("닉네임이 설정되었습니다.");
     }
 
-    /** 닉네임 조회 */
+    @Operation(summary = "닉네임 조회", description = "사용자의 현재 닉네임을 조회합니다.")
     @GetMapping("/nickname")
     public ResponseEntity<UserNicknameResponse> getNickname(
             @LoginUser User user
@@ -84,7 +79,7 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
-    /** 닉네임 수정 */
+    @Operation(summary = "닉네임 변경", description = "사용자의 닉네임을 변경합니다.")
     @PutMapping("/nickname")
     public ResponseEntity<String> updateNickname(
             @LoginUser User user,


### PR DESCRIPTION
### 관련이슈
- close #56 

### 목적
- 프로젝트 전체 API에 Swagger 문서 적용

### 내용
- Swagger 의존성 추가
- 불필요한 주석 제거
- Admin, 사용자 인증/인가, 신고 관리, 댓글, 모임, 게시글, 유저, 이미지 등 모든 컨트롤러에 Swagger 적용

### 확인 방법
- http://localhost:8080/swagger-ui.html 접속 후 API 문서 확인

### 참고 사항
- 앞으로  Operation과 Tag 어노테이션을 통해 api들을 swagger 문서화 할 수 있습니다