### PR TITLE
feat: Plan 도메인 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,166 @@
+name: Deploy to EC2 with GitHub Actions
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+jobs:
+  build-and-deploy:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      # 1) 코드 체크아웃
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # 2) JDK 21 설치 (빌드용)
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'corretto'
+
+      # 3) Gradle 캐시
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      # 4) gradlew 실행권한
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+
+      # 5) 빌드 (테스트 제외)
+      - name: Build with Gradle
+        run: ./gradlew build -x test
+
+      # 6) 빌드 산출물(SNAPSHOT) 파일명 추출 (단일 파일 보장)
+      - name: Find and export JAR file name
+        id: find_jar
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t FILES < <(find build/libs -maxdepth 1 -type f -name "*-SNAPSHOT.jar" | sort)
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "::error::No SNAPSHOT JAR file found in build/libs/"
+            exit 1
+          fi
+          JAR_FILE_PATH="${FILES[0]}"
+          JAR_FILE_NAME="$(basename "$JAR_FILE_PATH")"
+          echo "Found JAR file: $JAR_FILE_NAME"
+          echo "JAR_NAME=$JAR_FILE_NAME" >> "$GITHUB_OUTPUT"
+
+      # (디버그) 로컬 빌드 산출물 확인
+      - name: Debug - list local build/libs
+        run: ls -al build/libs
+
+      # 7) 원격 타겟 디렉터리 보장
+      - name: Ensure target dir on EC2
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_PEM_KEY }}
+          script: |
+            set -e
+            mkdir -p /home/${USER}/Team15_BE
+
+      # 8) 정확히 단일 파일만 전송 + 경로 납작화(strip_components: 2)
+      - name: Copy JAR to EC2 (flatten path)
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_PEM_KEY }}
+          source: "build/libs/${{ steps.find_jar.outputs.JAR_NAME }}"
+          target: "/home/${{ secrets.EC2_USER }}/Team15_BE"
+          overwrite: true
+          strip_components: 2
+
+      # 9) EC2에서 파일 존재 확인(루트에 존재해야 함)
+      - name: Verify file transfer on EC2
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_PEM_KEY }}
+          script: |
+            set -euo pipefail
+            APP_DIR="/home/${USER}/Team15_BE"
+            echo "--- Full listing of ${APP_DIR} ---"
+            ls -al "${APP_DIR}"
+            echo "--- Verifying specific file ---"
+            ls -l "${APP_DIR}/${{ steps.find_jar.outputs.JAR_NAME }}"
+
+      # 10) 배포 & 실행 (심볼릭 링크 + 안전한 중지)
+      - name: Deploy and Run on EC2
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_PEM_KEY }}
+          script: |
+            set -Eeuo pipefail
+            
+            APP_DIR="/home/${USER}/Team15_BE"
+            JAR_NAME="${{ steps.find_jar.outputs.JAR_NAME }}"
+            APP_JAR="app.jar"
+            LOG_DIR="${APP_DIR}/logs"
+            
+            cd "${APP_DIR}" || { echo "Failed to change directory to ${APP_DIR}"; exit 1; }
+            
+            if ! command -v java >/dev/null 2>&1; then
+              echo "ERROR: 'java' command not found on EC2. Install JDK/JRE first."
+              exit 1
+            fi
+            
+            if [ ! -f "${JAR_NAME}" ]; then
+              echo "ERROR: JAR not found: ${JAR_NAME}"
+              ls -al .
+              exit 1
+            fi
+            ln -sfn "${JAR_NAME}" "${APP_JAR}"
+            echo "Linked ${JAR_NAME} -> ${APP_JAR}"
+            
+            EXISTING_PID=$(lsof -t -i:8080 || true)
+            if [ -n "$EXISTING_PID" ]; then
+              echo "Port 8080 in use by PID=$EXISTING_PID. Stopping..."
+              kill -15 "$EXISTING_PID" || true
+              sleep 5
+              if ps -p "$EXISTING_PID" > /dev/null 2>&1; then
+                echo "Process still alive. Sending SIGKILL..."
+                kill -9 "$EXISTING_PID" || true
+                sleep 2
+              fi
+            else
+              echo "No process using port 8080."
+            fi
+            
+            mkdir -p "${LOG_DIR}"
+            LOG_FILE_NAME="$(date +'%Y-%m-%d_%H-%M-%S').log"
+            LOG_FILE_PATH="${LOG_DIR}/${LOG_FILE_NAME}"
+            
+            echo "Starting new application (${APP_JAR})... Logging to ${LOG_FILE_PATH}"
+            nohup java -Dspring.profiles.active=dev -jar "${APP_JAR}" > "${LOG_FILE_PATH}" 2>&1 &
+            
+            APP_PID=$!
+            echo "App PID: $APP_PID"
+            sleep 15
+            if ps -p $APP_PID > /dev/null 2>&1; then
+              echo "✅ Application started successfully. PID=$APP_PID"
+            else
+              echo "❌ ERROR: Application failed to start. Last 120 log lines:"
+              tail -n 120 "${LOG_FILE_PATH}" || true
+              exit 1
+            fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
           key: ${{ secrets.EC2_PEM_KEY }}
           script: |
             set -e
-            mkdir -p /home/${USER}/Team15_BE
+            mkdir -p /home/${USER}/Team16_BE
 
       # 8) 정확히 단일 파일만 전송 + 경로 납작화(strip_components: 2)
       - name: Copy JAR to EC2 (flatten path)
@@ -84,7 +84,7 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_PEM_KEY }}
           source: "build/libs/${{ steps.find_jar.outputs.JAR_NAME }}"
-          target: "/home/${{ secrets.EC2_USER }}/Team15_BE"
+          target: "/home/${{ secrets.EC2_USER }}/Team16_BE"
           overwrite: true
           strip_components: 2
 
@@ -97,7 +97,7 @@ jobs:
           key: ${{ secrets.EC2_PEM_KEY }}
           script: |
             set -euo pipefail
-            APP_DIR="/home/${USER}/Team15_BE"
+            APP_DIR="/home/${USER}/Team16_BE"
             echo "--- Full listing of ${APP_DIR} ---"
             ls -al "${APP_DIR}"
             echo "--- Verifying specific file ---"
@@ -113,7 +113,7 @@ jobs:
           script: |
             set -Eeuo pipefail
             
-            APP_DIR="/home/${USER}/Team15_BE"
+            APP_DIR="/home/${USER}/Team16_BE"
             JAR_NAME="${{ steps.find_jar.outputs.JAR_NAME }}"
             APP_JAR="app.jar"
             LOG_DIR="${APP_DIR}/logs"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,0 @@
-# GroundRule CRUD
-
-**구현 내역**
-
-- [x] GroundRule 엔티티
-- [x] GroundRule 컨트롤러 
-- [x] GroundRule 서비스 
-- [x] GroundRule 레포지토리
-- [x] GroundRule Dto

--- a/src/main/java/com/kakaotechcampus/team16be/aws/service/S3UploadPresignedUrlService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/service/S3UploadPresignedUrlService.java
@@ -79,7 +79,7 @@ public class S3UploadPresignedUrlService {
 
     public String getPublicUrl(String fileName) {
         if (fileName == null) {
-            return amazonS3Client.getUrl(bucket, defaultCoverImageUrl).toString();
+            return null;
         }
         return amazonS3Client.getUrl(bucket, fileName).toString();
     }

--- a/src/main/java/com/kakaotechcampus/team16be/groundrule/GroundRule.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groundrule/GroundRule.java
@@ -2,7 +2,10 @@ package com.kakaotechcampus.team16be.groundrule;
 
 import com.kakaotechcampus.team16be.common.BaseEntity;
 import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.group.exception.GroupErrorCode;
+import com.kakaotechcampus.team16be.group.exception.GroupException;
 import jakarta.persistence.*;
+import java.util.Objects;
 import lombok.Getter;
 
 @Entity
@@ -31,5 +34,15 @@ public class GroundRule extends BaseEntity {
 
   public void changeContent(String newContent) {
     this.content = newContent;
+  }
+
+  public boolean belongsTo(Long groupId){
+    return Objects.equals(group.getId(), groupId);
+  }
+
+  public void validateAccess(Long groupId) {
+    if (!belongsTo(groupId)) {
+      throw new GroupException(GroupErrorCode.WRONG_GROUP_ACCESS);
+    }
   }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/groundrule/GroundRuleController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groundrule/GroundRuleController.java
@@ -35,23 +35,30 @@ public class GroundRuleController {
   }
 
   @Operation(summary = "그라운드룰 수정", description = "특정 모임의 기존 그라운드룰을 수정합니다.")
-  @PutMapping("/{groupId}/rule")
+  @PutMapping("/{groupId}/rule/{ruleId}")
   public ResponseEntity<GroundRuleResponseDto> updateGroundRule(
       @PathVariable Long groupId,
+      @PathVariable Long ruleId,
       @RequestBody GroundRuleRequestDto groundRuleRequestDto) {
-    return ResponseEntity.ok(groundRuleService.updateGroundRule(groupId, groundRuleRequestDto));
+    return ResponseEntity.ok(groundRuleService.updateGroundRule(groupId, ruleId, groundRuleRequestDto));
   }
 
   @Operation(summary = "그라운드룰 조회", description = "특정 모임의 그라운드룰을 조회합니다.")
-  @GetMapping("/{groupId}/rule")
-  public ResponseEntity<GroundRuleResponseDto> getGroundRule(@PathVariable Long groupId) {
-    return ResponseEntity.ok(groundRuleService.getGroundRule(groupId));
+  @GetMapping("/{groupId}/rule/{ruleId}")
+  public ResponseEntity<GroundRuleResponseDto> getGroundRule(
+      @PathVariable Long groupId,
+      @PathVariable Long ruleId
+  ) {
+    return ResponseEntity.ok(groundRuleService.getGroundRule(groupId, ruleId));
   }
 
   @Operation(summary = "그라운드룰 삭제", description = "특정 모임의 그라운드룰을 삭제합니다.")
-  @DeleteMapping("/{groupId}/rule")
-  public ResponseEntity<Void> deleteGroundRule(@PathVariable Long groupId) {
-    groundRuleService.deleteGroundRule(groupId);
+  @DeleteMapping("/{groupId}/rule/{ruleId}")
+  public ResponseEntity<Void> deleteGroundRule(
+      @PathVariable Long groupId,
+      @PathVariable Long ruleId
+    ) {
+    groundRuleService.deleteGroundRule(groupId, ruleId);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/groundrule/GroundRuleRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groundrule/GroundRuleRepository.java
@@ -1,5 +1,6 @@
 package com.kakaotechcampus.team16be.groundrule;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -7,4 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface GroundRuleRepository extends JpaRepository<GroundRule, Long>{
   Optional<GroundRule> findByGroupId(Long groupId);
+  List<GroundRule> findAllByGroupId(Long groupId);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/groundrule/dto/GroundRuleResponseDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groundrule/dto/GroundRuleResponseDto.java
@@ -1,9 +1,12 @@
 package com.kakaotechcampus.team16be.groundrule.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+
 public record GroundRuleResponseDto(
     String content,
-    String createdAt,
-    String updatedAt
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
 ) {
 
   public static GroundRuleResponseDto empty(){

--- a/src/main/java/com/kakaotechcampus/team16be/groundrule/service/GroundRuleService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groundrule/service/GroundRuleService.java
@@ -7,7 +7,7 @@ import com.kakaotechcampus.team16be.groundrule.dto.GroundRuleResponseDto;
 public interface GroundRuleService {
 
   GroundRuleResponseDto saveGroundRule(Long groupId, GroundRuleRequestDto groundRuleRequestDto);
-  GroundRuleResponseDto getGroundRule(Long groupId);
-  GroundRuleResponseDto updateGroundRule(Long groupId, GroundRuleRequestDto groundRuleRequestDto);
-  void deleteGroundRule(Long groupId);
+  GroundRuleResponseDto getGroundRule(Long groupId, Long ruleId);
+  GroundRuleResponseDto updateGroundRule(Long groupId, Long ruleId, GroundRuleRequestDto groundRuleRequestDto);
+  void deleteGroundRule(Long groupId, Long ruleId);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/groundrule/service/GroundRuleServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groundrule/service/GroundRuleServiceImpl.java
@@ -4,6 +4,8 @@ import com.kakaotechcampus.team16be.groundrule.GroundRule;
 import com.kakaotechcampus.team16be.groundrule.GroundRuleRepository;
 import com.kakaotechcampus.team16be.groundrule.dto.GroundRuleRequestDto;
 import com.kakaotechcampus.team16be.groundrule.dto.GroundRuleResponseDto;
+import com.kakaotechcampus.team16be.groundrule.exception.GroundRuleErrorCode;
+import com.kakaotechcampus.team16be.groundrule.exception.GroundRuleException;
 import com.kakaotechcampus.team16be.group.domain.Group;
 import com.kakaotechcampus.team16be.group.exception.GroupErrorCode;
 import com.kakaotechcampus.team16be.group.exception.GroupException;
@@ -20,7 +22,6 @@ public class GroundRuleServiceImpl implements GroundRuleService {
 
   private final GroundRuleRepository groundRuleRepository;
   private final GroupService groupService;
-  private final GroupRepository groupRepository;
 
   @Override
   @Transactional
@@ -33,39 +34,42 @@ public class GroundRuleServiceImpl implements GroundRuleService {
   }
 
   @Override
-  public GroundRuleResponseDto getGroundRule(Long groupId) {
-    Group group = groupService.findGroupById(groupId);
+  public GroundRuleResponseDto getGroundRule(Long groupId, Long ruleId) {
+    GroundRule groundRule = groundRuleRepository.findById(ruleId)
+        .orElseThrow(() -> new GroundRuleException(GroundRuleErrorCode.RULE_NOT_FOUND));
 
-    return groundRuleRepository.findById(groupId)
-                               .map(this::toDto)
-                               .orElse(GroundRuleResponseDto.empty());
+    groundRule.validateAccess(groupId);
+    return toDto(groundRule);
   }
 
   @Override
   @Transactional
-  public GroundRuleResponseDto updateGroundRule(Long groupId, GroundRuleRequestDto groundRuleRequestDto) {
-    if (!groupRepository.existsById(groupId)) {
-      throw new GroupException(GroupErrorCode.GROUP_CANNOT_FOUND);
-    }
+  public GroundRuleResponseDto updateGroundRule(Long groupId, Long ruleId, GroundRuleRequestDto groundRuleRequestDto) {
+    GroundRule groundRule = groundRuleRepository.findById(ruleId)
+                                                .orElseThrow(() -> new GroundRuleException(GroundRuleErrorCode.RULE_NOT_FOUND));
 
-    GroundRule groundRule = groundRuleRepository.findByGroupId(groupId)
-                                                .orElseThrow(() -> new RuntimeException("그라운드 룰이 존재하지 않습니다."));
-
+    groundRule.validateAccess(groupId);
     groundRule.changeContent(groundRuleRequestDto.content());
     return toDto(groundRule);
   }
 
   @Override
   @Transactional
-  public void deleteGroundRule(Long groupId) {
-    groundRuleRepository.deleteById(groupId);
+  public void deleteGroundRule(Long groupId, Long ruleId) {
+    GroundRule groundRule = groundRuleRepository.findById(ruleId)
+                                                .orElseThrow(() -> new GroundRuleException(GroundRuleErrorCode.RULE_NOT_FOUND));
+
+    groundRule.validateAccess(groupId);
+    groundRuleRepository.delete(groundRule);
   }
 
   private GroundRuleResponseDto toDto(GroundRule groundRule) {
     return new GroundRuleResponseDto(
         groundRule.getContent(),
-        groundRule.getCreatedAt() != null ? groundRule.getCreatedAt().toString() : null,
-        groundRule.getUpdatedAt() != null ? groundRule.getUpdatedAt().toString() : null
+        groundRule.getCreatedAt(),
+        groundRule.getUpdatedAt()
     );
   }
+
+
 }

--- a/src/main/java/com/kakaotechcampus/team16be/group/controller/RequestSignGroupDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/controller/RequestSignGroupDto.java
@@ -1,0 +1,4 @@
+package com.kakaotechcampus.team16be.group.controller;
+
+public record RequestSignGroupDto() {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/group/controller/ResponseSignDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/controller/ResponseSignDto.java
@@ -1,0 +1,4 @@
+package com.kakaotechcampus.team16be.group.controller;
+
+public class ResponseSignDto {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/group/domain/Group.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/domain/Group.java
@@ -17,9 +17,6 @@ import org.springframework.beans.factory.annotation.Value;
 @Table(name = "groups")
 public class Group extends BaseEntity {
 
-    @Value("${cloud.aws.s3.default-image-url}")
-    private String defaultCoverImageUrl;
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -59,16 +56,19 @@ public class Group extends BaseEntity {
         this.name = name;
         this.intro = intro;
         this.capacity = capacity;
+        this.coverImageUrl="";
     }
 
     public static Group createGroup(User user, String name, String intro, Integer capacity) {
-        return new Group(user, name, intro, capacity);
+        return Group.builder().
+                user(user).
+                name(name).
+                intro(intro).
+                capacity(capacity).
+                build();
     }
 
     public Group update(String updatedName, String updatedIntro, Integer updatedCapacity) {
-        if (updatedName == null && updatedIntro == null && updatedCapacity == null) {
-            throw new GroupException(GroupErrorCode.GROUP_NO_INPUT);
-        }
         if (updatedCapacity != null && updatedCapacity <= 0) {
             throw new GroupException(GroupErrorCode.WRONG_GROUP_CAPACITY);
         }
@@ -85,16 +85,9 @@ public class Group extends BaseEntity {
     }
 
     public void changeCoverImage(String newImageUrl) {
-        if (newImageUrl == null || newImageUrl.isEmpty()) {
-            this.coverImageUrl = defaultCoverImageUrl;
-        } else {
-            this.coverImageUrl = newImageUrl;
-        }
+        this.coverImageUrl = newImageUrl;
     }
 
-    public String returnDefaultImgUrl() {
-        return defaultCoverImageUrl;
-    }
 
     public void checkLeader(User user) {
         if (!(this.leader == user)) {

--- a/src/main/java/com/kakaotechcampus/team16be/group/exception/GroupErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/exception/GroupErrorCode.java
@@ -15,7 +15,8 @@ public enum GroupErrorCode {
     GROUP_NO_INPUT(HttpStatus.BAD_REQUEST, "GROUP-004", "입력 값이 존재하지 않습니다."),
     GROUP_CANNOT_FOUND(HttpStatus.NOT_FOUND, "GROUP-005", "모임이 존재하지 않습니다."),
     GROUP_NO_AUTHORITY(HttpStatus.FORBIDDEN, "GROUP-006", "해당 권한이 없습니다."),
-    GROUP_NO_FILENAME(HttpStatus.BAD_REQUEST, "GROUP-007", "해당 파일이 없습니다.");
+    GROUP_NO_FILENAME(HttpStatus.BAD_REQUEST, "GROUP-007", "해당 파일이 없습니다."),
+    WRONG_GROUP_ACCESS(HttpStatus.FORBIDDEN, "GROUP-009", "잘못된 그룹 접근입니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
@@ -98,7 +98,7 @@ public class GroupServiceImpl implements GroupService {
         targetGroup.changeCoverImage(updatedImgUrl);
 
         boolean isImageChanged = !Objects.equals(updatedImgUrl, oldImgUrl);
-        boolean isOldImageDefault = (oldImgUrl == null || oldImgUrl.equals(targetGroup.returnDefaultImgUrl()));
+        boolean isOldImageDefault = (oldImgUrl == null);
 
         if (isImageChanged && !isOldImageDefault) {
             s3UploadPresignedUrlService.deleteImage(oldImgUrl);

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/controller/GroupMemberController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/controller/GroupMemberController.java
@@ -1,0 +1,55 @@
+package com.kakaotechcampus.team16be.groupMember.controller;
+
+
+import com.kakaotechcampus.team16be.common.annotation.LoginUser;
+import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
+import com.kakaotechcampus.team16be.groupMember.dto.RequestGroupMemberDto;
+import com.kakaotechcampus.team16be.groupMember.dto.ResponseGroupMemberDto;
+import com.kakaotechcampus.team16be.groupMember.service.GroupMemberService;
+import com.kakaotechcampus.team16be.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/group")
+public class GroupMemberController {
+
+    private final GroupMemberService groupMemberService;
+
+    @PostMapping("/join")
+    public ResponseEntity<ResponseGroupMemberDto> joinGroup(@LoginUser User user, @RequestBody RequestGroupMemberDto requestGroupMemberDto) {
+        groupMemberService.joinGroup(requestGroupMemberDto.groupId(), requestGroupMemberDto.userId(), user.getId());
+
+        System.out.println(requestGroupMemberDto.groupId());
+
+        return ResponseEntity.ok(ResponseGroupMemberDto.success(HttpStatus.CREATED, "해당 유저를 그룹에 가입 승인했습니다"));
+    }
+
+    @PostMapping("/leave")
+    public ResponseEntity<ResponseGroupMemberDto> leaveGroup(@LoginUser User user, @RequestBody RequestGroupMemberDto requestGroupMemberDto) {
+        GroupMember groupMember = groupMemberService.leaveGroup(requestGroupMemberDto.groupId(), user.getId());
+
+        return ResponseEntity.ok(ResponseGroupMemberDto.success(HttpStatus.OK, groupMember.getUser().getNickname() + "가 그룹을 탈퇴했습니다."));
+    }
+
+    @PostMapping("/banned")
+    public ResponseEntity<ResponseGroupMemberDto> bannedMember(@LoginUser User user, @RequestBody RequestGroupMemberDto requestGroupMemberDto) {
+        GroupMember groupMember = groupMemberService.bannedGroup(requestGroupMemberDto.groupId(), requestGroupMemberDto.userId(), user);
+
+
+        return ResponseEntity.ok(ResponseGroupMemberDto.success(HttpStatus.OK, groupMember.getUser().getNickname() + "가 그룹에서 강퇴당했습니다"));
+    }
+
+    @PostMapping("/sign")
+    public ResponseEntity<ResponseGroupMemberDto> signGroup(@LoginUser User user, @RequestBody RequestGroupMemberDto requestGroupMemberDto) {
+        GroupMember groupMember = groupMemberService.signGroup(user, requestGroupMemberDto.groupId());
+
+        return ResponseEntity.ok(ResponseGroupMemberDto.success(HttpStatus.CREATED, "가입신청을 완료했습니다."));
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/domain/GroupMember.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/domain/GroupMember.java
@@ -1,0 +1,135 @@
+package com.kakaotechcampus.team16be.groupMember.domain;
+
+import com.kakaotechcampus.team16be.common.BaseEntity;
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.groupMember.exception.GroupMemberException;
+import com.kakaotechcampus.team16be.user.domain.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+
+import java.time.LocalDateTime;
+
+import static com.kakaotechcampus.team16be.groupMember.domain.GroupMemberStatus.*;
+import static com.kakaotechcampus.team16be.groupMember.domain.GroupRole.*;
+import static com.kakaotechcampus.team16be.groupMember.exception.ErrorCode.*;
+
+@Entity
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "group_members")
+public class GroupMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private GroupRole role;
+
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private GroupMemberStatus status;
+
+    private LocalDateTime leftAt;
+
+    @CreatedDate
+    private LocalDateTime joinAt;
+
+    @Builder
+    public GroupMember(Group group, User user, GroupRole role, GroupMemberStatus status) {
+        this.group = group;
+        this.user = user;
+        this.role = role;
+        this.status = status;
+    }
+
+    protected GroupMember() {
+
+    }
+
+    public static GroupMember join(Group group, User user) {
+
+        return GroupMember.builder().
+                group(group).
+                user(user).
+                role(MEMBER).
+                status(ACTIVE).
+                build();
+    }
+
+    public static void checkLeftGroup(GroupMember member) {
+        if (member.getRole() == GroupRole.LEADER) {
+            throw new GroupMemberException(LEADER_CANNOT_LEAVE);
+        }
+
+        if (member.getStatus() == LEFT) {
+            throw new GroupMemberException(MEMBER_ALREADY_LEFT);
+        }
+
+    }
+
+    public static GroupMember create(Group createdGroup, User user) {
+        return GroupMember.builder().
+                group(createdGroup).
+                user(user).role(LEADER).
+                status(ACTIVE).
+                build();
+    }
+
+    public static GroupMember sign(User signedUser, Group targetGroup) {
+        return GroupMember.builder().
+                group(targetGroup).
+                user(signedUser).role(MEMBER).
+                status(PENDING).
+                build();
+    }
+
+    public void join() throws GroupMemberException {
+        if (this.status == LEFT) {
+            this.status = ACTIVE;
+        }
+        if (this.status == ACTIVE) {
+            throw new GroupMemberException(GROUP_MEMBER_ALREADY_EXIST);
+        }
+        if (this.status == GroupMemberStatus.BANNED) {
+            throw new GroupMemberException(MEMBER_HAS_BANNED);
+        }else
+            this.status = ACTIVE;
+    }
+
+    public void leaveGroup() {
+        this.status = LEFT;
+        this.leftAt = LocalDateTime.now();
+    }
+
+    public void bannedGroup() {
+        if (this.status == BANNED) {
+            throw new GroupMemberException(MEMBER_ALREADY_BANNED);
+        }
+        this.status = BANNED;
+        this.leftAt = LocalDateTime.now();
+    }
+
+    public void checkUserInGroup(User user) {
+        if (!this.user.getId().equals(user.getId())) {
+            throw new GroupMemberException(GROUP_MEMBER_ALREADY_EXIST);
+        }
+
+    }
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/domain/GroupMemberStatus.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/domain/GroupMemberStatus.java
@@ -1,0 +1,8 @@
+package com.kakaotechcampus.team16be.groupMember.domain;
+
+public enum GroupMemberStatus {
+    ACTIVE,
+    LEFT,
+    BANNED,
+    PENDING
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/domain/GroupRole.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/domain/GroupRole.java
@@ -1,0 +1,7 @@
+package com.kakaotechcampus.team16be.groupMember.domain;
+
+public enum GroupRole {
+    LEADER,
+    MANAGER,
+    MEMBER
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/RequestGroupMemberDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/RequestGroupMemberDto.java
@@ -1,0 +1,4 @@
+package com.kakaotechcampus.team16be.groupMember.dto;
+
+public record RequestGroupMemberDto(Long groupId, Long userId) {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/ResponseGroupMemberDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/ResponseGroupMemberDto.java
@@ -1,7 +1,7 @@
 package com.kakaotechcampus.team16be.groupMember.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.kakaotechcampus.team16be.group.exception.ErrorCode;
+import com.kakaotechcampus.team16be.groupMember.exception.ErrorCode;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/ResponseGroupMemberDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/ResponseGroupMemberDto.java
@@ -1,0 +1,30 @@
+package com.kakaotechcampus.team16be.groupMember.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.kakaotechcampus.team16be.group.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class ResponseGroupMemberDto {
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    public static ResponseGroupMemberDto success(HttpStatus status, String message) {
+        return new ResponseGroupMemberDto(status.value(), "", message);
+    }
+
+    public static ResponseGroupMemberDto error(ErrorCode errorCode) {
+        return new ResponseGroupMemberDto(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage());
+    }
+
+    private ResponseGroupMemberDto(int status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/exception/ErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.kakaotechcampus.team16be.groupMember.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    GROUP_MEMBER_ALREADY_EXIST(HttpStatus.CONFLICT, "GROUP_MEMBER-001", "이미 그룹에 속해있는 멤버입니다."),
+    GROUP_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP_MEMBER-002", "해당 유저는 그룹의 멤버가 아닙니다."),
+    LEADER_CANNOT_JOIN(HttpStatus.BAD_REQUEST, "GROUP_MEMBER-003", "그룹장은 그룹에 멤버로 가입할 수 없습니다."),
+    LEADER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "GROUP_MEMBER-004", "그룹장은 그룹을 탈퇴할 수 없습니다."),
+    MEMBER_ALREADY_LEFT(HttpStatus.BAD_REQUEST, "GROUP_MEMBER-005", "이미 탈퇴한 멤버입니다."),
+    MEMBER_HAS_BANNED(HttpStatus.BAD_REQUEST, "GROUP_MEMBER-006", "강퇴당한 멤버는 가입할 수 없습니다."),
+    FAILED_TO_JOIN_GROUP(HttpStatus.BAD_REQUEST, "GROUP_MEMBER-007", "알 수 없는 이유로 그룹에 가입하지 못했습니다."),
+    MEMBER_ALREADY_BANNED(HttpStatus.BAD_REQUEST, "GROUP_MEMBER-008", "해당 유저는 이미 강퇴 당한 유저입니다.");
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/exception/GroupMemberException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/exception/GroupMemberException.java
@@ -1,0 +1,15 @@
+package com.kakaotechcampus.team16be.groupMember.exception;
+
+
+import lombok.Getter;
+
+@Getter
+public class GroupMemberException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public GroupMemberException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/exception/GroupMemberExceptionHandler.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/exception/GroupMemberExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.kakaotechcampus.team16be.groupMember.exception;
+
+import com.kakaotechcampus.team16be.group.dto.ResponseGroupDto;
+import com.kakaotechcampus.team16be.group.exception.ErrorCode;
+import com.kakaotechcampus.team16be.group.exception.GroupException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GroupMemberExceptionHandler {
+
+    @ExceptionHandler(GroupMemberException.class)
+    public ResponseEntity<ResponseGroupDto> GroupMemberExceptionHandler(GroupException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus()).body(ResponseGroupDto.error(errorCode));
+    }
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/exception/GroupMemberExceptionHandler.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/exception/GroupMemberExceptionHandler.java
@@ -1,8 +1,6 @@
 package com.kakaotechcampus.team16be.groupMember.exception;
 
-import com.kakaotechcampus.team16be.group.dto.ResponseGroupDto;
-import com.kakaotechcampus.team16be.group.exception.ErrorCode;
-import com.kakaotechcampus.team16be.group.exception.GroupException;
+import com.kakaotechcampus.team16be.groupMember.dto.ResponseGroupMemberDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,9 +9,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GroupMemberExceptionHandler {
 
     @ExceptionHandler(GroupMemberException.class)
-    public ResponseEntity<ResponseGroupDto> GroupMemberExceptionHandler(GroupException e) {
+    public ResponseEntity<ResponseGroupMemberDto> GroupMemberExceptionHandler(GroupMemberException e) {
         ErrorCode errorCode = e.getErrorCode();
-        return ResponseEntity.status(errorCode.getStatus()).body(ResponseGroupDto.error(errorCode));
+        return ResponseEntity.status(errorCode.getStatus()).body(ResponseGroupMemberDto.error(errorCode));
     }
 
 }

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/repository/GroupMemberRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/repository/GroupMemberRepository.java
@@ -1,0 +1,14 @@
+package com.kakaotechcampus.team16be.groupMember.repository;
+
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
+import com.kakaotechcampus.team16be.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface GroupMemberRepository extends JpaRepository<GroupMember,Long> {
+    Optional<GroupMember> findByGroupAndUser(Group group, User user);
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberService.java
@@ -1,0 +1,21 @@
+package com.kakaotechcampus.team16be.groupMember.service;
+
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
+import com.kakaotechcampus.team16be.user.domain.User;
+
+public interface GroupMemberService {
+    GroupMember joinGroup(Long groupId, Long joinerId,Long userId);
+
+    GroupMember leaveGroup(Long groupId, Long userId);
+
+    GroupMember bannedGroup(Long groupId, Long userId, User leader);
+
+    GroupMember findByGroupAndUser(Group group, User user);
+
+    boolean checkMemberHasLeft(Group targetGroup, User user);
+
+    void createGroup(Group createdGroup, User user);
+
+    GroupMember signGroup(User user, Long groupId);
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
@@ -1,0 +1,120 @@
+package com.kakaotechcampus.team16be.groupMember.service;
+
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.group.service.GroupService;
+import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
+import com.kakaotechcampus.team16be.groupMember.domain.GroupMemberStatus;
+import com.kakaotechcampus.team16be.groupMember.exception.ErrorCode;
+import com.kakaotechcampus.team16be.groupMember.exception.GroupMemberException;
+import com.kakaotechcampus.team16be.groupMember.repository.GroupMemberRepository;
+import com.kakaotechcampus.team16be.user.domain.User;
+import com.kakaotechcampus.team16be.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+
+@Service
+@RequiredArgsConstructor
+public class GroupMemberServiceImpl implements GroupMemberService {
+
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupService groupService;
+    private final UserService userService;
+
+
+    @Transactional
+    public GroupMember joinGroup(Long groupId, Long joinerId ,Long leaderId) {
+        Group group = groupService.findGroupById(groupId);
+
+        User user = userService.findById(leaderId);
+        checkGroupLeader(group,user.getId());
+
+        User joiner = userService.findById(joinerId);
+
+        Optional<GroupMember> existingMember = groupMemberRepository.findByGroupAndUser(group, joiner);
+
+        if (existingMember.isPresent()) {
+            GroupMember member = existingMember.get();
+            member.join();
+            return member;
+        } else {
+            GroupMember newMember = GroupMember.join(group, joiner);
+            return groupMemberRepository.save(newMember);
+        }
+
+    }
+
+    public GroupMember findByGroupAndUser(Group group, User user) {
+        return groupMemberRepository.findByGroupAndUser(group, user)
+                .orElseThrow(() -> new GroupMemberException(ErrorCode.GROUP_MEMBER_NOT_FOUND));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean checkMemberHasLeft(Group targetGroup, User user) {
+
+        return groupMemberRepository.findByGroupAndUser(targetGroup, user)
+                .map(member -> member.getStatus() == GroupMemberStatus.LEFT)
+                .orElse(false);
+    }
+
+    @Override
+    public void createGroup(Group createdGroup, User user) {
+
+        GroupMember groupMember = GroupMember.create(createdGroup, user);
+        groupMemberRepository.save(groupMember);
+    }
+
+    @Override
+    public GroupMember signGroup(User user, Long groupId) {
+        User signedUser = userService.findById(user.getId());
+        Group targetGroup = groupService.findGroupById(groupId);
+
+         GroupMember signMember = GroupMember.sign(signedUser, targetGroup);
+
+        return groupMemberRepository.save(signMember);
+    }
+
+
+    private void checkGroupLeader(Group group, Long userId) {
+        if (!group.getLeader().getId().equals(userId)) {
+            throw new GroupMemberException(ErrorCode.LEADER_CANNOT_JOIN);
+        }
+    }
+
+
+    @Transactional
+    public GroupMember leaveGroup(Long groupId, Long userId) {
+        Group group = groupService.findGroupById(groupId);
+
+        User user = userService.findById(userId);
+
+        GroupMember member = findByGroupAndUser(group, user);
+
+        GroupMember.checkLeftGroup(member);
+
+
+        member.leaveGroup();
+
+        return member;
+    }
+
+    @Transactional
+    public GroupMember bannedGroup(Long groupId, Long userId, User leaderUser) {
+        Group group = groupService.findGroupById(groupId);
+
+        group.checkLeader(leaderUser);
+
+        User bannedUser = userService.findById(userId);
+
+        GroupMember member = findByGroupAndUser(group, bannedUser);
+
+        member.bannedGroup();
+
+        return member;
+
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/plan/PlanController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/PlanController.java
@@ -1,0 +1,54 @@
+package com.kakaotechcampus.team16be.plan;
+
+import com.kakaotechcampus.team16be.plan.dto.PlanRequestDto;
+import com.kakaotechcampus.team16be.plan.dto.PlanResponseDto;
+import com.kakaotechcampus.team16be.plan.service.PlanService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/plans")
+public class PlanController {
+
+  private final PlanService planService;
+
+  @PostMapping
+  public ResponseEntity<PlanResponseDto> createPlan(@RequestBody PlanRequestDto planRequestDto){
+    return ResponseEntity.status(HttpStatus.CREATED).body(planService.createPlan(planRequestDto));
+  }
+
+  @GetMapping("/{planId}")
+  public ResponseEntity<PlanResponseDto> getPlan(@PathVariable Long planId){
+    return ResponseEntity.status(HttpStatus.OK).body(planService.getPlan(planId));
+  }
+
+  @GetMapping
+  public ResponseEntity<List<PlanResponseDto>> getAllPlans(){
+    return ResponseEntity.status(HttpStatus.OK).body(planService.getAllPlans());
+  }
+
+  @PatchMapping("/{planId}")
+  public ResponseEntity<PlanResponseDto> updatePlan(
+      @PathVariable Long planId,
+      @RequestBody PlanRequestDto planRequestDto
+  ){
+    return ResponseEntity.status(HttpStatus.OK).body(planService.updatePlan(planId, planRequestDto));
+  }
+
+  @DeleteMapping("/{planId}")
+  public ResponseEntity<Void> deletePlan(@PathVariable Long planId){
+    planService.deletePlan(planId);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/plan/PlanController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/PlanController.java
@@ -1,8 +1,10 @@
 package com.kakaotechcampus.team16be.plan;
 
+import com.kakaotechcampus.team16be.common.annotation.LoginUser;
 import com.kakaotechcampus.team16be.plan.dto.PlanRequestDto;
 import com.kakaotechcampus.team16be.plan.dto.PlanResponseDto;
 import com.kakaotechcampus.team16be.plan.service.PlanService;
+import com.kakaotechcampus.team16be.user.domain.User;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,37 +20,49 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/plans")
+@RequestMapping("/api")
 public class PlanController {
 
   private final PlanService planService;
 
-  @PostMapping
-  public ResponseEntity<PlanResponseDto> createPlan(@RequestBody PlanRequestDto planRequestDto){
-    return ResponseEntity.status(HttpStatus.CREATED).body(planService.createPlan(planRequestDto));
+  @PostMapping("/groups/{groupId}/plans")
+  public ResponseEntity<PlanResponseDto> createPlan(
+      @LoginUser User user,
+      @PathVariable Long groupId,
+      @RequestBody PlanRequestDto planRequestDto){
+    return ResponseEntity.status(HttpStatus.CREATED).body(planService.createPlan(user, groupId, planRequestDto));
   }
 
-  @GetMapping("/{planId}")
-  public ResponseEntity<PlanResponseDto> getPlan(@PathVariable Long planId){
-    return ResponseEntity.status(HttpStatus.OK).body(planService.getPlan(planId));
+  @GetMapping("/groups/{groupId}/plans/{planId}")
+  public ResponseEntity<PlanResponseDto> getPlan(
+      @PathVariable Long groupId,
+      @PathVariable Long planId){
+    return ResponseEntity.status(HttpStatus.OK).body(planService.getPlan(groupId, planId));
   }
 
-  @GetMapping
-  public ResponseEntity<List<PlanResponseDto>> getAllPlans(){
-    return ResponseEntity.status(HttpStatus.OK).body(planService.getAllPlans());
+  @GetMapping("/groups/{groupId}/plans")
+  public ResponseEntity<List<PlanResponseDto>> getAllPlans(
+      @PathVariable Long groupId
+  ){
+    return ResponseEntity.status(HttpStatus.OK).body(planService.getAllPlans(groupId));
   }
 
-  @PatchMapping("/{planId}")
+  @PatchMapping("/groups/{groupId}/plans/{planId}")
   public ResponseEntity<PlanResponseDto> updatePlan(
+      @LoginUser User user,
+      @PathVariable Long groupId,
       @PathVariable Long planId,
       @RequestBody PlanRequestDto planRequestDto
   ){
-    return ResponseEntity.status(HttpStatus.OK).body(planService.updatePlan(planId, planRequestDto));
+    return ResponseEntity.status(HttpStatus.OK).body(planService.updatePlan(user, groupId, planId, planRequestDto));
   }
 
-  @DeleteMapping("/{planId}")
-  public ResponseEntity<Void> deletePlan(@PathVariable Long planId){
-    planService.deletePlan(planId);
+  @DeleteMapping("/groups/{groupId}/plans/{planId}")
+  public ResponseEntity<Void> deletePlan(
+      @LoginUser User user,
+      @PathVariable Long groupId,
+      @PathVariable Long planId){
+    planService.deletePlan(user, groupId, planId);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/plan/PlanRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/PlanRepository.java
@@ -2,10 +2,14 @@ package com.kakaotechcampus.team16be.plan;
 
 
 import com.kakaotechcampus.team16be.plan.domain.Plan;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PlanRepository extends JpaRepository<Plan, Long> {
+  Optional<Plan> findByGroupIdAndId(Long groupId, Long planId);
+  List<Plan> findByGroupId(Long groupId);
 
 }

--- a/src/main/java/com/kakaotechcampus/team16be/plan/PlanRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/PlanRepository.java
@@ -11,5 +11,4 @@ import org.springframework.stereotype.Repository;
 public interface PlanRepository extends JpaRepository<Plan, Long> {
   Optional<Plan> findByGroupIdAndId(Long groupId, Long planId);
   List<Plan> findByGroupId(Long groupId);
-
 }

--- a/src/main/java/com/kakaotechcampus/team16be/plan/PlanRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/PlanRepository.java
@@ -1,0 +1,11 @@
+package com.kakaotechcampus.team16be.plan;
+
+
+import com.kakaotechcampus.team16be.plan.domain.Plan;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/plan/domain/Plan.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/domain/Plan.java
@@ -1,0 +1,77 @@
+package com.kakaotechcampus.team16be.plan.domain;
+
+import com.kakaotechcampus.team16be.common.BaseEntity;
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.plan.dto.PlanRequestDto;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Plan extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "group_id", nullable = false)
+  private Group group;
+
+  @Column(name = "title", nullable = false)
+  private String title;
+
+  @Column(name = "description")
+  private String description;
+
+  @Column(name = "capacity", nullable = false)
+  private int capacity;
+
+  @Column(name = "start_time", nullable = false)
+  private LocalDateTime startTime;
+
+  @Column(name = "end_time", nullable = false)
+  private LocalDateTime endTime;
+
+  @Builder
+  public Plan(Group group, String title, String description, int capacity, LocalDateTime startTime, LocalDateTime endTime){
+    if(capacity <= 0){
+      throw new IllegalArgumentException("참여 인원은 1명 이상이어야 합니다.");
+    }
+    if (startTime.isAfter(endTime)) {
+      throw new IllegalArgumentException("시작 시간이 종료 시간 이후일 수 없습니다.");
+    }
+
+    this.group = group;
+    this.title = title;
+    this.description = description;
+    this.capacity = capacity;
+    this.startTime = startTime;
+    this.endTime = endTime;
+  }
+
+  public void changePlan(PlanRequestDto dto) {
+    if (dto.title() != null)
+      this.title = dto.title();
+    if (dto.description() != null)
+      this.description = dto.description();
+    if (dto.capacity() <= 0)
+      this.capacity = dto.capacity();
+    if (dto.startTime() != null)
+      this.startTime = dto.startTime();
+    if (dto.endTime() != null)
+      this.endTime = dto.endTime();
+  }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/plan/domain/Plan.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/domain/Plan.java
@@ -37,7 +37,7 @@ public class Plan extends BaseEntity {
   private String description;
 
   @Column(name = "capacity", nullable = false)
-  private int capacity;
+  private Integer capacity;
 
   @Column(name = "start_time", nullable = false)
   private LocalDateTime startTime;
@@ -46,7 +46,7 @@ public class Plan extends BaseEntity {
   private LocalDateTime endTime;
 
   @Builder
-  public Plan(Group group, String title, String description, int capacity, LocalDateTime startTime, LocalDateTime endTime){
+  public Plan(Group group, String title, String description, Integer capacity, LocalDateTime startTime, LocalDateTime endTime){
     if(capacity <= 0){
       throw new IllegalArgumentException("참여 인원은 1명 이상이어야 합니다.");
     }
@@ -65,12 +65,17 @@ public class Plan extends BaseEntity {
   public void changePlan(PlanRequestDto dto) {
     if (dto.title() != null)
       this.title = dto.title();
+
     if (dto.description() != null)
       this.description = dto.description();
-    if (dto.capacity() <= 0)
-      this.capacity = dto.capacity();
+
+    if (dto.capacity() != null){
+      if(dto.capacity() <= 0) throw new IllegalArgumentException("참가 인원 수는 1명 이상이어야 합니다.");
+    }
+
     if (dto.startTime() != null)
       this.startTime = dto.startTime();
+
     if (dto.endTime() != null)
       this.endTime = dto.endTime();
   }

--- a/src/main/java/com/kakaotechcampus/team16be/plan/dto/PlanRequestDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/dto/PlanRequestDto.java
@@ -3,12 +3,10 @@ package com.kakaotechcampus.team16be.plan.dto;
 import java.time.LocalDateTime;
 
 public record PlanRequestDto(
-    Long groupId,
     String title,
     String description,
-    int capacity,
+    Integer capacity,
     LocalDateTime startTime,
     LocalDateTime endTime
 ) {
-
 }

--- a/src/main/java/com/kakaotechcampus/team16be/plan/dto/PlanRequestDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/dto/PlanRequestDto.java
@@ -1,0 +1,14 @@
+package com.kakaotechcampus.team16be.plan.dto;
+
+import java.time.LocalDateTime;
+
+public record PlanRequestDto(
+    Long groupId,
+    String title,
+    String description,
+    int capacity,
+    LocalDateTime startTime,
+    LocalDateTime endTime
+) {
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/plan/dto/PlanRequestDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/dto/PlanRequestDto.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 public record PlanRequestDto(
     String title,
     String description,
-    Integer capacity,
+    int capacity,
     LocalDateTime startTime,
     LocalDateTime endTime
 ) {

--- a/src/main/java/com/kakaotechcampus/team16be/plan/dto/PlanRequestDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/dto/PlanRequestDto.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 public record PlanRequestDto(
     String title,
     String description,
-    int capacity,
+    Integer capacity,
     LocalDateTime startTime,
     LocalDateTime endTime
 ) {

--- a/src/main/java/com/kakaotechcampus/team16be/plan/dto/PlanResponseDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/dto/PlanResponseDto.java
@@ -1,0 +1,13 @@
+package com.kakaotechcampus.team16be.plan.dto;
+
+import java.time.LocalDateTime;
+
+public record PlanResponseDto(
+    Long groupId,
+    String title,
+    String description,
+    int capacity,
+    LocalDateTime startTime,
+    LocalDateTime endTime
+) {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/plan/dto/PlanResponseDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/dto/PlanResponseDto.java
@@ -3,11 +3,13 @@ package com.kakaotechcampus.team16be.plan.dto;
 import java.time.LocalDateTime;
 
 public record PlanResponseDto(
-    Long groupId,
+    Long id,
     String title,
     String description,
-    int capacity,
+    Integer capacity,
     LocalDateTime startTime,
-    LocalDateTime endTime
+    LocalDateTime endTime,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
 ) {
 }

--- a/src/main/java/com/kakaotechcampus/team16be/plan/exception/PlanErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/exception/PlanErrorCode.java
@@ -1,0 +1,16 @@
+package com.kakaotechcampus.team16be.plan.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PlanErrorCode {
+
+  PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN-001", "일정이 존재하지 않습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/kakaotechcampus/team16be/plan/exception/PlanException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/exception/PlanException.java
@@ -1,0 +1,13 @@
+package com.kakaotechcampus.team16be.plan.exception;
+
+import lombok.Getter;
+
+@Getter
+public class PlanException extends RuntimeException {
+
+  private final PlanErrorCode planErrorCode;
+  public PlanException(PlanErrorCode planErrorCode) {
+    super(planErrorCode.getMessage());
+    this.planErrorCode = planErrorCode;
+  }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanService.java
@@ -3,13 +3,14 @@ package com.kakaotechcampus.team16be.plan.service;
 
 import com.kakaotechcampus.team16be.plan.dto.PlanRequestDto;
 import com.kakaotechcampus.team16be.plan.dto.PlanResponseDto;
+import com.kakaotechcampus.team16be.user.domain.User;
 import java.util.List;
 
 public interface PlanService {
 
-  PlanResponseDto createPlan(PlanRequestDto planRequestDto);
-  PlanResponseDto getPlan(Long planId);
-  List<PlanResponseDto> getAllPlans();
-  PlanResponseDto updatePlan(Long planId, PlanRequestDto planRequestDto);
-  void deletePlan(Long planId);
+  PlanResponseDto createPlan(User user, Long groupId, PlanRequestDto planRequestDto);
+  PlanResponseDto getPlan(Long groupId, Long planId);
+  List<PlanResponseDto> getAllPlans(Long groupId);
+  PlanResponseDto updatePlan(User user, Long groupId, Long planId, PlanRequestDto planRequestDto);
+  void deletePlan(User user, Long groupId, Long planId);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanService.java
@@ -1,0 +1,15 @@
+package com.kakaotechcampus.team16be.plan.service;
+
+
+import com.kakaotechcampus.team16be.plan.dto.PlanRequestDto;
+import com.kakaotechcampus.team16be.plan.dto.PlanResponseDto;
+import java.util.List;
+
+public interface PlanService {
+
+  PlanResponseDto createPlan(PlanRequestDto planRequestDto);
+  PlanResponseDto getPlan(Long planId);
+  List<PlanResponseDto> getAllPlans();
+  PlanResponseDto updatePlan(Long planId, PlanRequestDto planRequestDto);
+  void deletePlan(Long planId);
+}

--- a/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanServiceImpl.java
@@ -1,0 +1,87 @@
+package com.kakaotechcampus.team16be.plan.service;
+
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.group.service.GroupService;
+import com.kakaotechcampus.team16be.plan.PlanRepository;
+import com.kakaotechcampus.team16be.plan.domain.Plan;
+import com.kakaotechcampus.team16be.plan.dto.PlanRequestDto;
+import com.kakaotechcampus.team16be.plan.dto.PlanResponseDto;
+import com.kakaotechcampus.team16be.plan.exception.PlanErrorCode;
+import com.kakaotechcampus.team16be.plan.exception.PlanException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlanServiceImpl implements PlanService {
+
+  private final PlanRepository planRepository;
+  private final GroupService groupService;
+
+
+  @Override
+  @Transactional
+  public PlanResponseDto createPlan(PlanRequestDto planRequestDto) {
+    Group group = groupService.findGroupById(planRequestDto.groupId());
+
+    Plan plan = Plan.builder()
+                    .group(group)
+                    .title(planRequestDto.title())
+                    .description(planRequestDto.description())
+                    .capacity(planRequestDto.capacity())
+                    .startTime(planRequestDto.startTime())
+                    .endTime(planRequestDto.endTime())
+                    .build();
+
+    Plan saved = planRepository.save(plan);
+    return toDto(saved);
+  }
+
+  @Override
+  public PlanResponseDto getPlan(Long planId) {
+    Plan plan = planRepository.findById(planId)
+        .orElseThrow(() -> new PlanException(PlanErrorCode.PLAN_NOT_FOUND));
+
+    return toDto(plan);
+  }
+
+  @Override
+  public List<PlanResponseDto> getAllPlans() {
+    return planRepository.findAll()
+        .stream()
+        .map(this::toDto)
+        .toList();
+  }
+
+  @Override
+  @Transactional
+  public PlanResponseDto updatePlan(Long planId, PlanRequestDto planRequestDto) {
+    Group group = groupService.findGroupById(planRequestDto.groupId());
+
+    Plan plan = planRepository.findById(planId)
+                              .orElseThrow(() -> new PlanException(PlanErrorCode.PLAN_NOT_FOUND));
+
+    plan.changePlan(planRequestDto);
+    return toDto(plan);
+  }
+
+  @Override
+  @Transactional
+  public void deletePlan(Long planId) {
+    planRepository.deleteById(planId);
+  }
+
+  public PlanResponseDto toDto(Plan plan){
+    return new PlanResponseDto(
+        plan.getGroup().getId(),
+        plan.getTitle(),
+        plan.getDescription(),
+        plan.getCapacity(),
+        plan.getStartTime(),
+        plan.getEndTime()
+    );
+  }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/common/dto/BaseReviewCreateDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/common/dto/BaseReviewCreateDto.java
@@ -1,0 +1,8 @@
+package com.kakaotechcampus.team16be.review.common.dto;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BaseReviewCreateDto implements ReviewCreateDto {
+    private String content;
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/common/dto/ResponseReviewDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/common/dto/ResponseReviewDto.java
@@ -2,7 +2,7 @@ package com.kakaotechcampus.team16be.review.common.dto;
 
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.kakaotechcampus.team16be.group.exception.ErrorCode;
+import com.kakaotechcampus.team16be.review.common.exception.ErrorCode;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/kakaotechcampus/team16be/review/common/dto/ResponseReviewDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/common/dto/ResponseReviewDto.java
@@ -1,0 +1,30 @@
+package com.kakaotechcampus.team16be.review.common.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.kakaotechcampus.team16be.group.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class ResponseReviewDto {
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    public static ResponseReviewDto success(HttpStatus status, String message) {
+        return new ResponseReviewDto(status.value(), "", message);
+    }
+
+    public static ResponseReviewDto error(ErrorCode errorCode) {
+        return new ResponseReviewDto(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage());
+    }
+
+    private ResponseReviewDto(int status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/common/dto/ReviewCreateDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/common/dto/ReviewCreateDto.java
@@ -1,0 +1,5 @@
+package com.kakaotechcampus.team16be.review.common.dto;
+
+
+public interface ReviewCreateDto {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/common/exception/ErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/common/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.kakaotechcampus.team16be.review.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    ACTIVE_CANNOT_REVIEW(HttpStatus.FORBIDDEN, "REVIEW-001", "탈퇴한 회원에 대해서만 리뷰가 가능합니다.");
+
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/common/exception/ReviewException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/common/exception/ReviewException.java
@@ -1,0 +1,15 @@
+package com.kakaotechcampus.team16be.review.common.exception;
+
+
+import lombok.Getter;
+
+@Getter
+public class ReviewException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public ReviewException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/common/exception/ReviewExceptionHandler.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/common/exception/ReviewExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.kakaotechcampus.team16be.review.common.exception;
+
+import com.kakaotechcampus.team16be.group.dto.ResponseGroupDto;
+import com.kakaotechcampus.team16be.group.exception.ErrorCode;
+import com.kakaotechcampus.team16be.group.exception.GroupException;
+import com.kakaotechcampus.team16be.groupMember.exception.GroupMemberException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ReviewExceptionHandler {
+
+    @ExceptionHandler(GroupMemberException.class)
+    public ResponseEntity<ResponseGroupDto> GroupMemberExceptionHandler(GroupException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus()).body(ResponseGroupDto.error(errorCode));
+    }
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/common/exception/ReviewExceptionHandler.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/common/exception/ReviewExceptionHandler.java
@@ -1,9 +1,6 @@
 package com.kakaotechcampus.team16be.review.common.exception;
 
-import com.kakaotechcampus.team16be.group.dto.ResponseGroupDto;
-import com.kakaotechcampus.team16be.group.exception.ErrorCode;
-import com.kakaotechcampus.team16be.group.exception.GroupException;
-import com.kakaotechcampus.team16be.groupMember.exception.GroupMemberException;
+import com.kakaotechcampus.team16be.review.common.dto.ResponseReviewDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,10 +8,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class ReviewExceptionHandler {
 
-    @ExceptionHandler(GroupMemberException.class)
-    public ResponseEntity<ResponseGroupDto> GroupMemberExceptionHandler(GroupException e) {
+    @ExceptionHandler(ReviewException.class)
+    public ResponseEntity<ResponseReviewDto> ReviewExceptionHandler(ReviewException e) {
         ErrorCode errorCode = e.getErrorCode();
-        return ResponseEntity.status(errorCode.getStatus()).body(ResponseGroupDto.error(errorCode));
+        return ResponseEntity.status(errorCode.getStatus()).body(ResponseReviewDto.error(errorCode));
     }
 
 }

--- a/src/main/java/com/kakaotechcampus/team16be/review/common/service/ReviewService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/common/service/ReviewService.java
@@ -1,0 +1,12 @@
+package com.kakaotechcampus.team16be.review.common.service;
+
+import com.kakaotechcampus.team16be.review.common.dto.ReviewCreateDto;
+import com.kakaotechcampus.team16be.user.domain.User;
+
+import java.util.List;
+
+public interface ReviewService<ReviewCreateReq extends ReviewCreateDto, Review> {
+    Review createReview(User user, ReviewCreateReq createReviewDto);
+
+    List<Review> getAllReviews(User user,Long groupId);
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/groupReview/controller/GroupReviewController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/groupReview/controller/GroupReviewController.java
@@ -1,0 +1,42 @@
+package com.kakaotechcampus.team16be.review.groupReview.controller;
+
+import com.kakaotechcampus.team16be.common.annotation.LoginUser;
+import com.kakaotechcampus.team16be.review.common.dto.ResponseReviewDto;
+import com.kakaotechcampus.team16be.review.common.service.ReviewService;
+import com.kakaotechcampus.team16be.review.groupReview.domain.GroupReview;
+import com.kakaotechcampus.team16be.review.groupReview.dto.CreateGroupReviewDto;
+import com.kakaotechcampus.team16be.review.groupReview.dto.ResponseGroupReviewListDto;
+import com.kakaotechcampus.team16be.user.domain.User;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/groups/reviews")
+public class GroupReviewController {
+
+    private final ReviewService reviewService;
+
+    public GroupReviewController(@Qualifier("groupReviewServiceImpl") ReviewService reviewService) {
+        this.reviewService = reviewService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ResponseReviewDto> createGroupReview(@LoginUser User user, @RequestBody CreateGroupReviewDto createGroupReviewDto) {
+        reviewService.createReview(user, createGroupReviewDto);
+
+        return ResponseEntity.ok(ResponseReviewDto.success(HttpStatus.OK, "그룹 리뷰를 성공적으로 생성했습니다."));
+    }
+
+    @GetMapping("/{groupId}")
+    public ResponseEntity<List<ResponseGroupReviewListDto>> getAllGroupReviews(@LoginUser User user, @PathVariable Long groupId) {
+        List<GroupReview> reviews = reviewService.getAllReviews(user,groupId);
+        List<ResponseGroupReviewListDto> result = ResponseGroupReviewListDto.from(reviews);
+
+        return ResponseEntity.ok(result);
+    }
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/groupReview/domain/GroupReview.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/groupReview/domain/GroupReview.java
@@ -1,0 +1,47 @@
+package com.kakaotechcampus.team16be.review.groupReview.domain;
+
+import com.kakaotechcampus.team16be.common.BaseEntity;
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.user.domain.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class GroupReview extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id",nullable = false)
+    private Group group;
+
+    @NotBlank
+    private String content;
+
+    protected GroupReview() {
+    }
+
+    @Builder
+    public GroupReview(User user, Group group, String content) {
+        this.user = user;
+        this.group = group;
+        this.content = content;
+    }
+
+    public static GroupReview createReview(User user, Group targetGroup, String content) {
+        return GroupReview.builder().
+                user(user).
+                group(targetGroup).
+                content(content).
+                build();
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/groupReview/dto/CreateGroupReviewDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/groupReview/dto/CreateGroupReviewDto.java
@@ -1,0 +1,10 @@
+package com.kakaotechcampus.team16be.review.groupReview.dto;
+
+
+import com.kakaotechcampus.team16be.review.common.dto.BaseReviewCreateDto;
+import lombok.Getter;
+
+@Getter
+public class CreateGroupReviewDto extends BaseReviewCreateDto {
+    private Long groupId;
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/groupReview/dto/ResponseGroupReviewListDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/groupReview/dto/ResponseGroupReviewListDto.java
@@ -1,0 +1,20 @@
+package com.kakaotechcampus.team16be.review.groupReview.dto;
+
+import com.kakaotechcampus.team16be.review.groupReview.domain.GroupReview;
+
+import java.util.List;
+
+public record ResponseGroupReviewListDto(String contents) {
+
+    public static ResponseGroupReviewListDto from(GroupReview groupReview) {
+        return new ResponseGroupReviewListDto(
+                groupReview.getContent());
+
+    }
+
+    public static List<ResponseGroupReviewListDto> from(List<GroupReview> groupReviews) {
+        return groupReviews.stream()
+                .map(ResponseGroupReviewListDto::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/groupReview/repository/GroupReviewRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/groupReview/repository/GroupReviewRepository.java
@@ -1,0 +1,17 @@
+package com.kakaotechcampus.team16be.review.groupReview.repository;
+
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.review.groupReview.domain.GroupReview;
+import com.kakaotechcampus.team16be.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GroupReviewRepository extends JpaRepository<GroupReview,Integer> {
+
+    List<GroupReview> findAllByUser(User user);
+
+    List<GroupReview> findAllByGroup(Group group);
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/groupReview/service/GroupReviewServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/groupReview/service/GroupReviewServiceImpl.java
@@ -1,0 +1,54 @@
+package com.kakaotechcampus.team16be.review.groupReview.service;
+
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.group.exception.ErrorCode;
+import com.kakaotechcampus.team16be.group.exception.GroupException;
+import com.kakaotechcampus.team16be.group.service.GroupService;
+import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
+import com.kakaotechcampus.team16be.groupMember.service.GroupMemberService;
+import com.kakaotechcampus.team16be.review.common.service.ReviewService;
+import com.kakaotechcampus.team16be.review.groupReview.domain.GroupReview;
+import com.kakaotechcampus.team16be.review.groupReview.dto.CreateGroupReviewDto;
+import com.kakaotechcampus.team16be.review.groupReview.repository.GroupReviewRepository;
+import com.kakaotechcampus.team16be.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GroupReviewServiceImpl implements ReviewService<CreateGroupReviewDto, GroupReview> {
+
+    private final GroupReviewRepository groupReviewRepository;
+    private final GroupService groupService;
+    private final GroupMemberService groupMemberService;
+
+
+
+    @Transactional
+    @Override
+    public GroupReview createReview(User user, CreateGroupReviewDto createGroupReviewDto) {
+        Group targetGroup = groupService.findGroupById(createGroupReviewDto.getGroupId());
+
+        groupMemberService.findByGroupAndUser(targetGroup, user);
+
+        boolean checkMemberLeft = groupMemberService.checkMemberHasLeft(targetGroup,user);
+
+        if (checkMemberLeft) {
+            return groupReviewRepository.save(GroupReview.createReview(user, targetGroup, createGroupReviewDto.getContent()));
+        }
+        else
+            throw new RuntimeException();
+
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<GroupReview> getAllReviews(User user,Long groupId) {
+        Group targetGroup = groupService.findGroupById(groupId);
+
+        return groupReviewRepository.findAllByGroup(targetGroup);
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/groupReview/service/GroupReviewServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/groupReview/service/GroupReviewServiceImpl.java
@@ -1,10 +1,7 @@
 package com.kakaotechcampus.team16be.review.groupReview.service;
 
 import com.kakaotechcampus.team16be.group.domain.Group;
-import com.kakaotechcampus.team16be.group.exception.ErrorCode;
-import com.kakaotechcampus.team16be.group.exception.GroupException;
 import com.kakaotechcampus.team16be.group.service.GroupService;
-import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
 import com.kakaotechcampus.team16be.groupMember.service.GroupMemberService;
 import com.kakaotechcampus.team16be.review.common.service.ReviewService;
 import com.kakaotechcampus.team16be.review.groupReview.domain.GroupReview;

--- a/src/main/java/com/kakaotechcampus/team16be/review/memberReview/controller/MemberReviewController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/memberReview/controller/MemberReviewController.java
@@ -1,0 +1,41 @@
+package com.kakaotechcampus.team16be.review.memberReview.controller;
+
+import com.kakaotechcampus.team16be.common.annotation.LoginUser;
+import com.kakaotechcampus.team16be.review.common.dto.ResponseReviewDto;
+import com.kakaotechcampus.team16be.review.common.service.ReviewService;
+import com.kakaotechcampus.team16be.review.memberReview.domain.MemberReview;
+import com.kakaotechcampus.team16be.review.memberReview.dto.CreateMemberReviewDto;
+import com.kakaotechcampus.team16be.review.memberReview.dto.ResponseMemberReviewListDto;
+import com.kakaotechcampus.team16be.user.domain.User;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+public class MemberReviewController {
+
+    private final ReviewService reviewService;
+
+    public MemberReviewController(@Qualifier("memberReviewService") ReviewService reviewService) {
+        this.reviewService = reviewService;
+    }
+
+    @PostMapping("/review")
+    public ResponseEntity<ResponseReviewDto> createMemberReview(@LoginUser User user, @RequestBody CreateMemberReviewDto createMemberReviewDto) {
+        reviewService.createReview(user, createMemberReviewDto);
+
+        return ResponseEntity.ok(ResponseReviewDto.success(HttpStatus.OK, "탈퇴한 회원에 대한 리뷰를 성공적으로 생성했습니다."));
+    }
+
+    @GetMapping("{groupId}/review")
+    public ResponseEntity<List<ResponseMemberReviewListDto>> getMemberReviews(@LoginUser User user, @PathVariable Long groupId) {
+        List<MemberReview> reviews = reviewService.getAllReviews(user, groupId);
+        List<ResponseMemberReviewListDto> result = ResponseMemberReviewListDto.from(reviews);
+
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/memberReview/domain/Evaluation.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/memberReview/domain/Evaluation.java
@@ -1,0 +1,5 @@
+package com.kakaotechcampus.team16be.review.memberReview.domain;
+
+public enum Evaluation {
+    POSITIVE, NEGATIVE
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/memberReview/domain/MemberReview.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/memberReview/domain/MemberReview.java
@@ -1,0 +1,56 @@
+package com.kakaotechcampus.team16be.review.memberReview.domain;
+
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.user.domain.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class MemberReview {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewer_id", nullable = false)
+    private User reviewer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewee_id", nullable = false)
+    private User reviewee;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id",nullable = false)
+    private Group group;
+
+    @NotBlank
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    Evaluation evaluation;
+
+    @Builder
+    public MemberReview(User reviewer, User reviewee, Group group, String content, Evaluation evaluation) {
+        this.reviewer = reviewer;
+        this.reviewee = reviewee;
+        this.group = group;
+        this.content = content;
+        this.evaluation = evaluation;
+    }
+
+    protected MemberReview() {
+    }
+
+    public static MemberReview create(User reviewer, User reviewee, Group targetGroup, String content,Evaluation evaluation) {
+        return MemberReview.builder().
+                reviewee(reviewee).
+                reviewer(reviewer).
+                group(targetGroup).
+                content(content).
+                evaluation(evaluation).
+                build();
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/memberReview/dto/CreateMemberReviewDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/memberReview/dto/CreateMemberReviewDto.java
@@ -1,0 +1,12 @@
+package com.kakaotechcampus.team16be.review.memberReview.dto;
+
+import com.kakaotechcampus.team16be.review.common.dto.BaseReviewCreateDto;
+import com.kakaotechcampus.team16be.review.memberReview.domain.Evaluation;
+import lombok.Getter;
+
+@Getter
+public class CreateMemberReviewDto extends BaseReviewCreateDto {
+    private Long groupId;
+    private Long revieweeId;
+    private Evaluation evaluation;
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/memberReview/dto/ResponseMemberReviewListDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/memberReview/dto/ResponseMemberReviewListDto.java
@@ -1,0 +1,29 @@
+package com.kakaotechcampus.team16be.review.memberReview.dto;
+
+import com.kakaotechcampus.team16be.review.memberReview.domain.Evaluation;
+import com.kakaotechcampus.team16be.review.memberReview.domain.MemberReview;
+
+import java.util.List;
+
+public record ResponseMemberReviewListDto(
+        Long groupId,
+        String groupName,
+        String content,
+        Evaluation evaluation
+) {
+    public static ResponseMemberReviewListDto from(MemberReview memberReview) {
+
+        return new ResponseMemberReviewListDto(
+                memberReview.getGroup().getId(),
+                memberReview.getGroup().getName(),
+                memberReview.getContent(),
+                memberReview.getEvaluation()
+        );
+    }
+
+    public static List<ResponseMemberReviewListDto> from(List<MemberReview> memberReviews) {
+        return memberReviews.stream()
+                .map(ResponseMemberReviewListDto::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/memberReview/repository/MemberReviewRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/memberReview/repository/MemberReviewRepository.java
@@ -1,0 +1,14 @@
+package com.kakaotechcampus.team16be.review.memberReview.repository;
+
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.review.memberReview.domain.MemberReview;
+import com.kakaotechcampus.team16be.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MemberReviewRepository extends JpaRepository<MemberReview,Long> {
+    List<MemberReview> findByRevieweeAndGroup(User reviewee, Group group);
+}

--- a/src/main/java/com/kakaotechcampus/team16be/review/memberReview/service/MemberReviewService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/memberReview/service/MemberReviewService.java
@@ -1,0 +1,61 @@
+package com.kakaotechcampus.team16be.review.memberReview.service;
+
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.group.service.GroupService;
+import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
+import com.kakaotechcampus.team16be.groupMember.service.GroupMemberService;
+import com.kakaotechcampus.team16be.review.common.exception.ReviewException;
+import com.kakaotechcampus.team16be.review.common.service.ReviewService;
+import com.kakaotechcampus.team16be.review.memberReview.domain.Evaluation;
+import com.kakaotechcampus.team16be.review.memberReview.domain.MemberReview;
+import com.kakaotechcampus.team16be.review.memberReview.dto.CreateMemberReviewDto;
+import com.kakaotechcampus.team16be.review.memberReview.repository.MemberReviewRepository;
+import com.kakaotechcampus.team16be.user.domain.User;
+import com.kakaotechcampus.team16be.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.kakaotechcampus.team16be.groupMember.domain.GroupMemberStatus.ACTIVE;
+import static com.kakaotechcampus.team16be.review.common.exception.ErrorCode.ACTIVE_CANNOT_REVIEW;
+
+@Service
+@RequiredArgsConstructor
+
+public class MemberReviewService implements ReviewService<CreateMemberReviewDto, MemberReview> {
+
+    private final MemberReviewRepository memberReviewRepository;
+    private final GroupService groupService;
+    private final GroupMemberService groupMemberService;
+    private final UserService userService;
+
+    @Transactional
+    @Override
+    public MemberReview createReview(User user, CreateMemberReviewDto createReviewDto) {
+       Group targetGroup = groupService.findGroupById(createReviewDto.getGroupId());
+       User reviewee = userService.findById(createReviewDto.getRevieweeId());
+
+        GroupMember groupMember = groupMemberService.findByGroupAndUser(targetGroup, user);
+
+        groupMember.checkUserInGroup(user);
+        if (groupMember.getStatus().equals(ACTIVE)) {
+            throw new ReviewException(ACTIVE_CANNOT_REVIEW);
+        }
+
+        String content = createReviewDto.getContent();
+        Evaluation evaluation = createReviewDto.getEvaluation();
+        MemberReview memberReview = MemberReview.create(user, reviewee, targetGroup, content,evaluation);
+
+        return memberReviewRepository.save(memberReview);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<MemberReview> getAllReviews(User user, Long groupId) {
+        Group targetGroup = groupService.findGroupById(groupId);
+
+        return memberReviewRepository.findByRevieweeAndGroup(user, targetGroup);
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
@@ -76,12 +76,12 @@ public class UserService {
     @Transactional(readOnly = true)
     public String getProfileImage(Long userId) {
         User user = getUser(userId);
+        String profileImageUrl = user.getProfileImageUrl();
 
-        if (user.getProfileImageUrl() == null) {
-            throw new UserException(UserErrorCode.PROFILE_IMAGE_NOT_FOUND);
+        if (profileImageUrl == null) {
+            return null;
         }
-
-        return s3UploadPresignedUrlService.getPublicUrl(user.getProfileImageUrl());
+        return s3UploadPresignedUrlService.getPublicUrl(profileImageUrl);
     }
 
     private User getUser(Long userId) {

--- a/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
@@ -112,4 +112,9 @@ public class UserService {
         user.updateNickname(request.nickname());
         userRepository.save(user);
     }
+
+    public User findById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
 }


### PR DESCRIPTION
close #58 
## Plan Domain

dto는 밑과 같은 식으로 구성하였습니다.
`public record PlanRequestDto( //responseDto도 동일.
    Long groupId,
    String title,
    String description,
    int capacity,
    LocalDateTime startTime,
    LocalDateTime endTime
) {
}`

## **[API 테스트]** 

### groupId는 PathVariable로 받는게 아닌 RequestBody에 담았습니다. PathVariable로 담으면 RequestMapping의 origin address가 groups로 시작을 해서 본질을 숨긴 느낌이어서 body에 담아 오리진이 plans로 시작하게끔 하였습니다.

**1. CREATE (일정 생성 ResourePath: /api/plans)**
<img width="2031" height="1037" alt="image" src="https://github.com/user-attachments/assets/0c378b4e-d7bd-4b13-95df-021f33acf8fa" />

**2. GET (단건조회 ResourcePath: /api/plans/{planId})**
<img width="2027" height="1070" alt="image" src="https://github.com/user-attachments/assets/28a325bd-9390-4399-93fa-839508c0184c" />

**3. GET (전체조회 ResourcePath: /api/plans/)**
<img width="2011" height="1372" alt="image" src="https://github.com/user-attachments/assets/30e14b8b-ad9e-484f-be7b-1ea42ab174ff" />

**4. PATCH (부분 업데이트 ResourcePath: /api/plans/{planId})**
<img width="1799" height="781" alt="image" src="https://github.com/user-attachments/assets/ba64212d-a75b-4414-8e39-12fb232fc3a8" />

**5. DELETE (일정 삭제 ResourcePath: /api/plans/{planId})**
<img width="2017" height="845" alt="image" src="https://github.com/user-attachments/assets/213a2fa5-70ce-4cec-84f6-d4b960f4716e" />

