### PR TITLE
fix: 그룹 정보와 이미지 설정 분리 및 S3 이미지 업로드 및 저장 로직 변경

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/aws/controller/ImageController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/controller/ImageController.java
@@ -9,10 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/image")
@@ -32,5 +29,18 @@ public class ImageController {
                 user.getId(), request.fileExtension(), request.type());
         return ResponseEntity.ok(imageUrlDto);
     }
+
+    @Operation(summary = "S3 그룹 이미지  주소 요청", description = "이미지 업로드할 그룹 이미지 presigned-url을 반환합니다.")
+    @PostMapping("/presigned/groups/{groupId}")
+    public ResponseEntity<ImageUrlDto> createGroupPresignedUrl(
+            @LoginUser User user,
+            @PathVariable Long groupId,
+            @RequestBody IssuePresignedUrlRequest request
+    ) {
+        ImageUrlDto imageUrlDto = s3UploadPresignedUrlService.executeGroupImg(
+                user,groupId, request.fileExtension(), request.type());
+        return ResponseEntity.ok(imageUrlDto);
+    }
+
 
 }

--- a/src/main/java/com/kakaotechcampus/team16be/aws/controller/ImageController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/controller/ImageController.java
@@ -38,7 +38,7 @@ public class ImageController {
             @RequestBody IssuePresignedUrlRequest request
     ) {
         ImageUrlDto imageUrlDto = s3UploadPresignedUrlService.executeGroupImg(
-                user,groupId, request.fileExtension(), request.type());
+                user,groupId, request.fileExtension());
         return ResponseEntity.ok(imageUrlDto);
     }
 

--- a/src/main/java/com/kakaotechcampus/team16be/aws/service/S3UploadPresignedUrlService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/service/S3UploadPresignedUrlService.java
@@ -20,6 +20,8 @@ import java.net.URL;
 import java.util.Date;
 import java.util.UUID;
 
+import static com.kakaotechcampus.team16be.aws.domain.ImageUploadType.GROUP_ICON;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -108,13 +110,13 @@ public class S3UploadPresignedUrlService {
         return amazonS3Client.generatePresignedUrl(request).toString();
     }
 
-    public ImageUrlDto executeGroupImg(User user, Long groupId, ImageFileExtension fileExtension, ImageUploadType type) {
+    public ImageUrlDto executeGroupImg(User user, Long groupId, ImageFileExtension fileExtension) {
 
         Group targetGroup = groupService.findGroupById(groupId);
         targetGroup.checkLeader(user);
 
         String valueFileExtension = fileExtension.getUploadExtension();
-        String valueType = type.getType();
+        String valueType = String.valueOf(ImageUploadType.GROUP_ICON);
         String fileName = createGroupFileName(targetGroup.getId(), valueFileExtension, valueType);
         log.info(fileName);
 

--- a/src/main/java/com/kakaotechcampus/team16be/aws/service/S3UploadPresignedUrlService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/service/S3UploadPresignedUrlService.java
@@ -7,6 +7,10 @@ import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.kakaotechcampus.team16be.aws.domain.ImageFileExtension;
 import com.kakaotechcampus.team16be.aws.domain.ImageUploadType;
 import com.kakaotechcampus.team16be.aws.dto.ImageUrlDto;
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.group.service.GroupService;
+import com.kakaotechcampus.team16be.user.domain.User;
+import com.kakaotechcampus.team16be.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,6 +32,8 @@ public class S3UploadPresignedUrlService {
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
+
+    private final GroupService groupService;
 
     public ImageUrlDto execute(
             Long userId, ImageFileExtension fileExtension, ImageUploadType type
@@ -100,5 +106,26 @@ public class S3UploadPresignedUrlService {
                 .withExpiration(expiration);
 
         return amazonS3Client.generatePresignedUrl(request).toString();
+    }
+
+    public ImageUrlDto executeGroupImg(User user, Long groupId, ImageFileExtension fileExtension, ImageUploadType type) {
+
+        Group targetGroup = groupService.findGroupById(groupId);
+        targetGroup.checkLeader(user);
+
+        String valueFileExtension = fileExtension.getUploadExtension();
+        String valueType = type.getType();
+        String fileName = createGroupFileName(targetGroup.getId(), valueFileExtension, valueType);
+        log.info(fileName);
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                getGeneratePreSignedUrlRequest(bucket, fileName, valueFileExtension);
+        URL url = amazonS3Client.generatePresignedUrl(generatePresignedUrlRequest);
+
+        return ImageUrlDto.of(url.toString(), fileName);
+    }
+
+    private String createGroupFileName(Long groupId, String fileExtension, String valueType) {
+        return valueType + "/" + groupId + "/" + UUID.randomUUID() + "." + fileExtension;
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/group/controller/GroupController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/controller/GroupController.java
@@ -51,10 +51,17 @@ public class GroupController {
         return ResponseEntity.ok(ResponseGroupDto.success(HttpStatus.OK, "모임이 성공적으로 삭제되었습니다."));
     }
 
-    @Operation(summary = "모임 수정", description = "특정 모임의 정보를 수정합니다.")
+    @Operation(summary = "모임 정보 수정", description = "특정 모임의 정보를 수정합니다.")
     @PutMapping("/{groupId}")
     public ResponseEntity<ResponseUpdateGroupDto> updateGroup(@LoginUser User user, @PathVariable("groupId") Long groupId, @Valid @RequestBody UpdateGroupDto updateGroupDto) {
         Group group = groupService.updateGroup(user, groupId, updateGroupDto);
+        return ResponseEntity.ok(ResponseUpdateGroupDto.from(group));
+    }
+
+    @Operation(summary = "모임 이미지 수정", description = "특정 모임의 대표 이미지를 수정합니다.")
+    @PutMapping("/{groupId}/image")
+    public ResponseEntity<ResponseUpdateGroupDto> updateGroupImage(@LoginUser User user, @PathVariable("groupId") Long groupId, @Valid @RequestBody UpdateGroupDto updateGroupDto) {
+        Group group = groupService.updateGroupImage(user, groupId, updateGroupDto);
         return ResponseEntity.ok(ResponseUpdateGroupDto.from(group));
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/group/service/GroupService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/service/GroupService.java
@@ -6,6 +6,7 @@ import com.kakaotechcampus.team16be.group.dto.ResponseGroupListDto;
 import com.kakaotechcampus.team16be.group.dto.ResponseSingleGroupDto;
 import com.kakaotechcampus.team16be.group.dto.UpdateGroupDto;
 import com.kakaotechcampus.team16be.user.domain.User;
+import jakarta.validation.Valid;
 
 import java.util.List;
 
@@ -21,4 +22,6 @@ public interface GroupService {
     Group findGroupById(Long groupId);
 
     ResponseSingleGroupDto getGroup(Long groupId);
+
+    Group updateGroupImage(User user, Long groupId, UpdateGroupDto updateGroupDto);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
@@ -13,7 +13,6 @@ import com.kakaotechcampus.team16be.user.domain.User;
 import com.kakaotechcampus.team16be.user.exception.UserErrorCode;
 import com.kakaotechcampus.team16be.user.exception.UserException;
 import com.kakaotechcampus.team16be.user.repository.UserRepository;
-import com.kakaotechcampus.team16be.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -81,7 +80,6 @@ public class GroupServiceImpl implements GroupService {
     @Override
     public Group updateGroup(User user, Long groupId, UpdateGroupDto updateGroupDto) {
         Group targetGroup = findGroupById(groupId);
-        String oldImgUrl = targetGroup.getCoverImageUrl();
 
         User leader = userRepository.findById(user.getId()).orElseThrow(()->new UserException(UserErrorCode.USER_NOT_FOUND));
 
@@ -91,15 +89,6 @@ public class GroupServiceImpl implements GroupService {
         String updatedIntro = updateGroupDto.intro();
         Integer updatedCapacity = updateGroupDto.capacity();
         targetGroup.update(updatedName, updatedIntro, updatedCapacity);
-
-        String updatedImgUrl = updateGroupDto.coverImageUrl();
-        targetGroup.changeCoverImage(updatedImgUrl);
-
-        boolean isImageChanged = !Objects.equals(updatedImgUrl, oldImgUrl);
-
-        if (isImageChanged) {
-            s3UploadPresignedUrlService.deleteImage(oldImgUrl);
-        }
 
         return targetGroup;
 
@@ -118,6 +107,25 @@ public class GroupServiceImpl implements GroupService {
 
         return ResponseSingleGroupDto.from(targetGroup, fullUrl);
 
+    }
+    @Transactional
+    @Override
+    public Group updateGroupImage(User user, Long groupId, UpdateGroupDto UpdateGroupDto) {
+        Group targetGroup = findGroupById(groupId);
+        User leader = userRepository.findById(user.getId()).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        targetGroup.checkLeader(leader);
+
+        String oldImgUrl = targetGroup.getCoverImageUrl();
+        String updatedImgUrl = UpdateGroupDto.coverImageUrl();
+
+        targetGroup.changeCoverImage(updatedImgUrl);
+
+        boolean isImageChanged = !Objects.equals(updatedImgUrl, oldImgUrl);
+        if (isImageChanged&&!oldImgUrl.isEmpty()) {
+            s3UploadPresignedUrlService.deleteImage(oldImgUrl);
+        }
+
+        return targetGroup;
     }
 
     public boolean existGroupName(String groupName) {

--- a/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
@@ -14,19 +14,29 @@ import com.kakaotechcampus.team16be.user.exception.UserErrorCode;
 import com.kakaotechcampus.team16be.user.exception.UserException;
 import com.kakaotechcampus.team16be.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
 
-@RequiredArgsConstructor
 @Service
 public class GroupServiceImpl implements GroupService {
 
     private final GroupRepository groupRepository;
     private final UserRepository userRepository;
     private final S3UploadPresignedUrlService s3UploadPresignedUrlService;
+
+    public GroupServiceImpl(
+            GroupRepository groupRepository,
+            @Lazy S3UploadPresignedUrlService s3UploadPresignedUrlService, // <- @Lazy 추가
+            UserRepository userRepository
+    ) {
+        this.groupRepository = groupRepository;
+        this.s3UploadPresignedUrlService = s3UploadPresignedUrlService;
+        this.userRepository = userRepository;
+    }
 
 
     @Transactional


### PR DESCRIPTION
### 진행한 작업
1. 그룹 정보와 이미지 수정 로직 분리
 그룹에 대한 정보와 이미지 수정을 분리시켰습니다. 
 기존 코드 한 서비스에 너무나 많은 로직이 몰려있다는 것이 느껴져 분리시켜야겠다는 생각이 들었습니다.



2. S3 PresignedURL User / Group 분리
<img width="2245" height="322" alt="image" src="https://github.com/user-attachments/assets/27dc1dc8-0915-4d4c-80e1-1dd8964836fa" />
기존 로직을 살펴보니, Group 이미지가 각 UserId 별로 저장되어있다는 것이 확인되었습니다. 
그래서 S3서비스 계층에서 groupId를 전달 받아 groupId에 User가 해당 그룹의 그룹장 여부의 대한 로직을 추가하였고, 
이를 바탕으로 groupId에 대한 FileName을 생성하는 로직을 추가하였습니다.


3. ErrorCode 리팩토링
기존 작업중 develop을 pull 하여 충돌 해결할겸 ErrorCode를 리팩토링했습니다!

close #73  
