### PR TITLE
feat: Swagger UI에서 JWT 인증 테스트 가능하도록 설정

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/common/config/SwaggerConfig.java
+++ b/src/main/java/com/kakaotechcampus/team16be/common/config/SwaggerConfig.java
@@ -1,0 +1,29 @@
+package com.kakaotechcampus.team16be.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        final String securitySchemeName = "bearerAuth";
+
+        return new OpenAPI()
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName,
+                                new SecurityScheme()
+                                        .name(securitySchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        )
+                );
+    }
+}


### PR DESCRIPTION
### 관련이슈
- close #72 

### 내용
- Swagger UI에서 토큰 입력하고 API 테스트가 가능하도록 하기 위해 SwaggerConfig를 추가하고 설정을 해줬습니다.