### PR TITLE
fix: 사용자 프로필이미지 디폴트 값 설정

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/user/domain/User.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/domain/User.java
@@ -41,6 +41,7 @@ public class User extends BaseEntity {
 
     public User(String kakaoId) {
         this.kakaoId = kakaoId;
+        this.nickname = "익명";
         this.role = Role.USER;
         this.verificationStatus = VerificationStatus.UNVERIFIED;
     }


### PR DESCRIPTION
### 관련이슈
- close #75  

### 내용
- 디폴트 닉네임을 "익명"으로 설정