### PR TITLE
fix: 사용자 프로필이미지 조회로직에 이미지가 null일 경우 디폴트 값 설정

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
@@ -2,7 +2,6 @@ package com.kakaotechcampus.team16be.user.service;
 
 import com.kakaotechcampus.team16be.auth.dto.StudentVerificationStatusResponse;
 import com.kakaotechcampus.team16be.auth.dto.UpdateStudentIdImageRequest;
-import com.kakaotechcampus.team16be.aws.domain.ImageUploadType;
 import com.kakaotechcampus.team16be.aws.service.S3UploadPresignedUrlService;
 import com.kakaotechcampus.team16be.user.domain.User;
 import com.kakaotechcampus.team16be.user.dto.UserNicknameRequest;
@@ -17,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class UserService {
+
+    private static final String DEFAULT_PROFILE_IMAGE_KEY = "default/defaultUserImg.png";
 
     private final UserRepository userRepository;
     private final S3UploadPresignedUrlService s3UploadPresignedUrlService;
@@ -79,7 +80,7 @@ public class UserService {
         String profileImageUrl = user.getProfileImageUrl();
 
         if (profileImageUrl == null) {
-            return null;
+            return s3UploadPresignedUrlService.getPublicUrl(DEFAULT_PROFILE_IMAGE_KEY);
         }
         return s3UploadPresignedUrlService.getPublicUrl(profileImageUrl);
     }


### PR DESCRIPTION
### 관련이슈
- close #79 

### 작업내용
- 사용자 프로필 이미지 디폴트 값을 defaultimg로 수정합니다.

### 사유
- 사용자이미지없을때 null로 달라고 했었는데 다시 원래 방식이었던 defaultImg url을 주기로 하였음.