### PR TITLE
fix: 프로필 이미지 처리 방법 최종 수정 (null)

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/user/controller/UserController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/controller/UserController.java
@@ -53,11 +53,11 @@ public class UserController {
 
     @Operation(summary = "프로필 이미지 삭제", description = "사용자의 프로필 이미지를 삭제합니다.")
     @DeleteMapping("/profile-image")
-    public ResponseEntity<Void> deleteProfileImage(
+    public ResponseEntity<String> deleteProfileImage(
             @LoginUser User user
     ) {
         userService.deleteProfileImage(user.getId());
-        return ResponseEntity.status(HttpStatus.OK).build();
+        return ResponseEntity.ok("null");
     }
 
     @Operation(summary = "닉네임 등록", description = "사용자의 닉네임을 최초 등록합니다.")

--- a/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
@@ -17,8 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserService {
 
-    private static final String DEFAULT_PROFILE_IMAGE_KEY = "default/defaultUserImg.png";
-
     private final UserRepository userRepository;
     private final S3UploadPresignedUrlService s3UploadPresignedUrlService;
 
@@ -80,7 +78,7 @@ public class UserService {
         String profileImageUrl = user.getProfileImageUrl();
 
         if (profileImageUrl == null) {
-            return s3UploadPresignedUrlService.getPublicUrl(DEFAULT_PROFILE_IMAGE_KEY);
+            return null;
         }
         return s3UploadPresignedUrlService.getPublicUrl(profileImageUrl);
     }


### PR DESCRIPTION
### 관련이슈
- close #81 

### 내용
- 계속 이슈가 있었는데 결론적으로 프론트랑 최종 논의한 결과
- delete시 null 반환
- defaultImage => null 반환
- 이렇게 수정하기로 함.