### PR TITLE
fix: 프로필 이미지 업데이트 로직 수정

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
@@ -51,11 +51,9 @@ public class UserService {
     @Transactional
     public void createProfileImage(Long userId, String fileName) {
         User user = getUser(userId);
-
         if (user.getProfileImageUrl() != null) {
             throw new UserException(UserErrorCode.PROFILE_IMAGE_ALREADY_EXISTS);
         }
-
         user.updateProfileImageUrl(fileName);
         userRepository.save(user);
     }
@@ -63,11 +61,6 @@ public class UserService {
     @Transactional
     public void updateProfileImage(Long userId, String fileName) {
         User user = getUser(userId);
-
-        if (user.getProfileImageUrl() == null) {
-            throw new UserException(UserErrorCode.PROFILE_IMAGE_NOT_FOUND);
-        }
-
         user.updateProfileImageUrl(fileName);
         userRepository.save(user);
     }
@@ -76,7 +69,6 @@ public class UserService {
     public String getProfileImage(Long userId) {
         User user = getUser(userId);
         String profileImageUrl = user.getProfileImageUrl();
-
         if (profileImageUrl == null) {
             return null;
         }


### PR DESCRIPTION
### 관련이슈
- close #83 

### 내용
- 기존에는 profileImageUrl이 null일 때 업데이트 시 USER-007 예외가 발생하였으나 제거하였습니다.
- profileImageUrl의 기본 디폴트 값을 null로 수정했기 때문입니다.