### PR TITLE
Feat(Attend): 일정 출석 API

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/attend/controller/AttendController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/attend/controller/AttendController.java
@@ -1,0 +1,29 @@
+package com.kakaotechcampus.team16be.attend.controller;
+
+import com.kakaotechcampus.team16be.attend.domain.Attend;
+import com.kakaotechcampus.team16be.attend.service.AttendService;
+import com.kakaotechcampus.team16be.common.annotation.LoginUser;
+import com.kakaotechcampus.team16be.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/groups")
+@RequiredArgsConstructor
+@Tag(name = "그룹 일정 출석 API", description = "그룹 일정 출석 관련 API")
+public class AttendController {
+
+    private final AttendService attendService;
+
+    @Operation(summary = "그룹 일정 출석", description = "유저가 특정 그룹의 일정에 출석합니다.")
+    @PostMapping("/{groupId}/attend")
+    public ResponseEntity<ResponseAttendDto> attendGroup(@LoginUser User user, @PathVariable Long groupId, @RequestBody RequestAttendDto requestAttendDto) {
+        Attend attend = attendService.attendGroup(user, groupId,requestAttendDto);
+
+        return ResponseEntity.ok(ResponseAttendDto.success(HttpStatus.OK, "그룹 출석이 완료되었습니다. 출석 상태 : " + attend.getAttendStatus()));
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/attend/controller/RequestAttendDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/attend/controller/RequestAttendDto.java
@@ -1,0 +1,5 @@
+package com.kakaotechcampus.team16be.attend.controller;
+
+public record RequestAttendDto(Long planId) {
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/attend/controller/ResponseAttendDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/attend/controller/ResponseAttendDto.java
@@ -1,0 +1,29 @@
+package com.kakaotechcampus.team16be.attend.controller;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.kakaotechcampus.team16be.groupMember.exception.GroupMemberErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class ResponseAttendDto {
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    public static ResponseAttendDto success(HttpStatus status, String message) {
+        return new ResponseAttendDto(status.value(), "", message);
+    }
+
+    public static ResponseAttendDto error(GroupMemberErrorCode errorCode) {
+        return new ResponseAttendDto(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage());
+    }
+
+    private ResponseAttendDto(int status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/attend/domain/Attend.java
+++ b/src/main/java/com/kakaotechcampus/team16be/attend/domain/Attend.java
@@ -1,27 +1,71 @@
 package com.kakaotechcampus.team16be.attend.domain;
 
+import com.kakaotechcampus.team16be.common.BaseEntity;
+import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
 import com.kakaotechcampus.team16be.plan.domain.Plan;
 import com.kakaotechcampus.team16be.user.domain.User;
 import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
 
+import java.time.LocalDateTime;
+
+@Getter
 @Entity
-public class Attend {
+/***
+ * plan_id, group_member_id에 unique 제약 조건을 추가하여
+ * 동일한 그룹 멤버가 동일한 계획에 대해 여러 번 출석할 수 없도록 설정
+ */
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"plan_id", "group_member_id"})
+        }
+)
+public class Attend extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "group_member_id", nullable = false)
+    private GroupMember groupMember;
 
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     @Column(name = "attend_status", nullable = false)
     private AttendStatus attendStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "start_time", nullable = false)
+    @JoinColumn(name = "plan_id", nullable = false)
     private Plan plan;
 
+    protected Attend() {
+    }
 
+    @Builder
+    public Attend(GroupMember groupMember, Plan plan) {
+        this.groupMember = groupMember;
+        this.plan = plan;
+        this.attendStatus = checkAttendStatus(plan);
+    }
+
+    private AttendStatus checkAttendStatus(Plan plan) {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(plan.getStartTime())) {
+            return AttendStatus.PRESENT;
+        } else if (!now.isAfter(plan.getEndTime())) {
+            return AttendStatus.LATE;
+        } else {
+            return AttendStatus.ABSENT;
+        }
+    }
+
+
+    public static Attend attendPlan(GroupMember groupMember,Plan plan) {
+        return Attend.builder()
+                .groupMember(groupMember)
+                .plan(plan)
+                .build();
+    }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/attend/domain/Attend.java
+++ b/src/main/java/com/kakaotechcampus/team16be/attend/domain/Attend.java
@@ -1,0 +1,27 @@
+package com.kakaotechcampus.team16be.attend.domain;
+
+import com.kakaotechcampus.team16be.plan.domain.Plan;
+import com.kakaotechcampus.team16be.user.domain.User;
+import jakarta.persistence.*;
+
+@Entity
+public class Attend {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated
+    @Column(name = "attend_status", nullable = false)
+    private AttendStatus attendStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "start_time", nullable = false)
+    private Plan plan;
+
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/attend/domain/AttendStatus.java
+++ b/src/main/java/com/kakaotechcampus/team16be/attend/domain/AttendStatus.java
@@ -1,0 +1,8 @@
+package com.kakaotechcampus.team16be.attend.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum AttendStatus {
+    PRESENT, ABSENT, LATE
+}

--- a/src/main/java/com/kakaotechcampus/team16be/attend/repository/AttendRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/attend/repository/AttendRepository.java
@@ -1,0 +1,8 @@
+package com.kakaotechcampus.team16be.attend.repository;
+
+import com.kakaotechcampus.team16be.attend.domain.Attend;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AttendRepository extends JpaRepository<Attend, Long> {
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/attend/service/AttendService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/attend/service/AttendService.java
@@ -1,0 +1,9 @@
+package com.kakaotechcampus.team16be.attend.service;
+
+import com.kakaotechcampus.team16be.attend.controller.RequestAttendDto;
+import com.kakaotechcampus.team16be.attend.domain.Attend;
+import com.kakaotechcampus.team16be.user.domain.User;
+
+public interface AttendService {
+    Attend attendGroup(User user, Long groupId, RequestAttendDto requestAttendDto);
+}

--- a/src/main/java/com/kakaotechcampus/team16be/attend/service/AttendServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/attend/service/AttendServiceImpl.java
@@ -12,6 +12,7 @@ import com.kakaotechcampus.team16be.plan.service.PlanService;
 import com.kakaotechcampus.team16be.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +23,7 @@ public class AttendServiceImpl implements AttendService{
     private final GroupMemberService groupMemberService;
     private final GroupService groupService;
 
+    @Transactional
     @Override
     public Attend attendGroup(User user, Long groupId, RequestAttendDto requestAttendDto) {
         Group targetGroup = groupService.findGroupById(groupId);

--- a/src/main/java/com/kakaotechcampus/team16be/attend/service/AttendServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/attend/service/AttendServiceImpl.java
@@ -1,0 +1,35 @@
+package com.kakaotechcampus.team16be.attend.service;
+
+import com.kakaotechcampus.team16be.attend.controller.RequestAttendDto;
+import com.kakaotechcampus.team16be.attend.domain.Attend;
+import com.kakaotechcampus.team16be.attend.repository.AttendRepository;
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.group.service.GroupService;
+import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
+import com.kakaotechcampus.team16be.groupMember.service.GroupMemberService;
+import com.kakaotechcampus.team16be.plan.domain.Plan;
+import com.kakaotechcampus.team16be.plan.service.PlanService;
+import com.kakaotechcampus.team16be.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AttendServiceImpl implements AttendService{
+
+    private final AttendRepository attendRepository;
+    private final PlanService planService;
+    private final GroupMemberService groupMemberService;
+    private final GroupService groupService;
+
+    @Override
+    public Attend attendGroup(User user, Long groupId, RequestAttendDto requestAttendDto) {
+        Group targetGroup = groupService.findGroupById(groupId);
+        GroupMember groupMember = groupMemberService.findByGroupAndUser(targetGroup, user);
+        Plan plan = planService.findByGroupIdAndPlanId(groupId, requestAttendDto.planId());
+
+        Attend attend = Attend.attendPlan(groupMember, plan);
+
+        return attendRepository.save(attend);
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanService.java
@@ -1,6 +1,7 @@
 package com.kakaotechcampus.team16be.plan.service;
 
 
+import com.kakaotechcampus.team16be.plan.domain.Plan;
 import com.kakaotechcampus.team16be.plan.dto.PlanRequestDto;
 import com.kakaotechcampus.team16be.plan.dto.PlanResponseDto;
 import com.kakaotechcampus.team16be.user.domain.User;
@@ -13,4 +14,6 @@ public interface PlanService {
   List<PlanResponseDto> getAllPlans(Long groupId);
   PlanResponseDto updatePlan(User user, Long groupId, Long planId, PlanRequestDto planRequestDto);
   void deletePlan(User user, Long groupId, Long planId);
+
+  Plan findByGroupIdAndPlanId(Long groupId, Long planId);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanServiceImpl.java
@@ -86,7 +86,13 @@ public class PlanServiceImpl implements PlanService {
     planRepository.delete(plan);
   }
 
-  public PlanResponseDto toDto(Plan plan){
+    @Override
+    public Plan findByGroupIdAndPlanId(Long groupId, Long planId) {
+        return planRepository.findByGroupIdAndId(groupId, planId)
+            .orElseThrow(() -> new PlanException(PlanErrorCode.PLAN_NOT_FOUND));
+    }
+
+    public PlanResponseDto toDto(Plan plan){
     return new PlanResponseDto(
         plan.getId(),
         plan.getTitle(),


### PR DESCRIPTION
### 작업 내용
- 도메인 설계
기존 DB설계를 조금 수정했습니다. 해당 사용자가 Group 가입 여부를 판단하는 것이 더욱 합리적이라고 생각하기에 User를 필드로 사용하는 것 보단, GroupMember를 필드로 사용하는 것을 채택했습니다. 또한
```
@Table(
        uniqueConstraints = {
                @UniqueConstraint(columnNames = {"plan_id", "group_member_id"})
        }
)
```

를 추가하여 중복 출석을 방지했습니다.

- 출석 API
```
    private AttendStatus checkAttendStatus(Plan plan) {
        LocalDateTime now = LocalDateTime.now();

        if (now.isBefore(plan.getStartTime())) {
            return AttendStatus.PRESENT;
        } else if (!now.isAfter(plan.getEndTime())) {
            return AttendStatus.LATE;
        } else {
            return AttendStatus.ABSENT;
        }
    }
 ```

Plan에서의 시작 / 종료 시간을 요청하여 그에 따른 출석 여부를 판단했습니다


- close #90  