### PR TITLE
refactor: plan 도메인에 위도,경도,참여인원 수 추가 및 관련 로직들 수정

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/plan/domain/Plan.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/domain/Plan.java
@@ -3,6 +3,8 @@ package com.kakaotechcampus.team16be.plan.domain;
 import com.kakaotechcampus.team16be.common.BaseEntity;
 import com.kakaotechcampus.team16be.group.domain.Group;
 import com.kakaotechcampus.team16be.plan.dto.PlanRequestDto;
+import com.kakaotechcampus.team16be.plan.exception.PlanErrorCode;
+import com.kakaotechcampus.team16be.plan.exception.PlanException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -39,44 +41,137 @@ public class Plan extends BaseEntity {
   @Column(name = "capacity", nullable = false)
   private Integer capacity;
 
+  @Column(name = "attendee", nullable = false)
+  private Integer attendee;
+
   @Column(name = "start_time", nullable = false)
   private LocalDateTime startTime;
 
   @Column(name = "end_time", nullable = false)
   private LocalDateTime endTime;
 
+  @Column(name = "latitude", nullable = false)
+  private Double latitude;
+
+  @Column(name = "longitude", nullable = false)
+  private Double longitude;
+
   @Builder
-  public Plan(Group group, String title, String description, Integer capacity, LocalDateTime startTime, LocalDateTime endTime){
-    if(capacity <= 0){
-      throw new IllegalArgumentException("참여 인원은 1명 이상이어야 합니다.");
-    }
-    if (startTime.isAfter(endTime)) {
-      throw new IllegalArgumentException("시작 시간이 종료 시간 이후일 수 없습니다.");
-    }
+  public Plan(Group group, String title, String description, Integer capacity, Integer attendee,
+      LocalDateTime startTime, LocalDateTime endTime, Double latitude, Double longitude) {
+    validateCapacity(capacity);
+    validateAttendee(attendee);
+    validateTimeRange(startTime, endTime);
+    validateCoordinates(latitude, longitude);
 
     this.group = group;
     this.title = title;
     this.description = description;
     this.capacity = capacity;
+    this.attendee = attendee != null ? attendee : 0;
     this.startTime = startTime;
     this.endTime = endTime;
+    this.latitude = latitude;
+    this.longitude = longitude;
   }
 
   public void changePlan(PlanRequestDto dto) {
-    if (dto.title() != null)
+    LocalDateTime newStartTime = dto.startTime() != null ? dto.startTime() : this.startTime;
+    LocalDateTime newEndTime = dto.endTime() != null ? dto.endTime() : this.endTime;
+    validateTimeRange(newStartTime, newEndTime);
+
+    if(dto.title() != null) {
       this.title = dto.title();
-
-    if (dto.description() != null)
-      this.description = dto.description();
-
-    if (dto.capacity() != null){
-      if(dto.capacity() <= 0) throw new IllegalArgumentException("참가 인원 수는 1명 이상이어야 합니다.");
     }
 
-    if (dto.startTime() != null)
-      this.startTime = dto.startTime();
+    if(dto.description() != null) {
+      this.description = dto.description();
+    }
 
-    if (dto.endTime() != null)
-      this.endTime = dto.endTime();
+    if(dto.capacity() != null) {
+      validateCapacity(dto.capacity());
+      validateAttendeeCapacityRelation(dto.capacity(), this.attendee);
+      this.capacity = dto.capacity();
+    }
+
+    this.startTime = newStartTime;
+    this.endTime = newEndTime;
+
+    if(dto.latitude() != null && dto.longitude() != null) {
+      validateCoordinates(dto.latitude(), dto.longitude());
+      this.latitude = dto.latitude();
+      this.longitude = dto.longitude();
+    }
+  }
+
+  // =========== 출석체크랑 연계되는 메소드 ============
+  public void increaseAttendee() {
+    if(this.attendee >= this.capacity) {
+      throw new PlanException(PlanErrorCode.PLAN_FULL);
+    }
+    this.attendee++;
+  }
+
+  public void decreaseAttendee() {
+    if(this.attendee <= 0) {
+      throw new PlanException(PlanErrorCode.NO_ATTENDEE_TO_REMOVE);
+    }
+    this.attendee--;
+  }
+  // =========== 출석체크랑 연계되는 메소드 ============
+
+
+  public static Plan create(Group group, String title, String description,
+      Integer capacity, LocalDateTime startTime, LocalDateTime endTime,
+      Double latitude, Double longitude) {
+    return Plan.builder()
+               .group(group)
+               .title(title)
+               .description(description)
+               .capacity(capacity)
+               .attendee(0)
+               .startTime(startTime)
+               .endTime(endTime)
+               .latitude(latitude)
+               .longitude(longitude)
+               .build();
+  }
+
+  private void validateCapacity(Integer capacity) {
+    if(capacity == null || capacity <= 0) {
+      throw new PlanException(PlanErrorCode.INVALID_CAPACITY);
+    }
+  }
+
+  private void validateAttendee(Integer attendee) {
+    if(attendee != null && attendee < 0) {
+      throw new PlanException(PlanErrorCode.INVALID_ATTENDEE_COUNT);
+    }
+  }
+
+  private void validateAttendeeCapacityRelation(Integer capacity, Integer attendee) {
+    if(attendee > capacity) {
+      throw new PlanException(PlanErrorCode.ATTENDEE_EXCEEDS_CAPACITY);
+    }
+  }
+
+  private void validateTimeRange(LocalDateTime startTime, LocalDateTime endTime) {
+    if (startTime == null || endTime == null) {
+      throw new PlanException(PlanErrorCode.TIME_REQUIRED);
+    }
+
+    if (!startTime.isBefore(endTime)) {
+      throw new PlanException(PlanErrorCode.INVALID_TIME_RANGE);
+    }
+  }
+
+  private void validateCoordinates(Double latitude, Double longitude) {
+    if (latitude == null || longitude == null) {
+      throw new PlanException(PlanErrorCode.COORDINATES_REQUIRED);
+    }
+
+    if (latitude < -90.0 || latitude > 90.0 || longitude < -180.0 || longitude > 180.0) {
+      throw new PlanException(PlanErrorCode.INVALID_COORDINATE);
+    }
   }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/plan/dto/PlanRequestDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/dto/PlanRequestDto.java
@@ -6,7 +6,10 @@ public record PlanRequestDto(
     String title,
     String description,
     Integer capacity,
+    Integer attendee,
     LocalDateTime startTime,
-    LocalDateTime endTime
+    LocalDateTime endTime,
+    Double latitude,
+    Double longitude
 ) {
 }

--- a/src/main/java/com/kakaotechcampus/team16be/plan/dto/PlanResponseDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/dto/PlanResponseDto.java
@@ -7,9 +7,12 @@ public record PlanResponseDto(
     String title,
     String description,
     Integer capacity,
+    Integer attendee,
     LocalDateTime startTime,
     LocalDateTime endTime,
     LocalDateTime createdAt,
-    LocalDateTime updatedAt
+    LocalDateTime updatedAt,
+    Double latitude,
+    Double longitude
 ) {
 }

--- a/src/main/java/com/kakaotechcampus/team16be/plan/exception/PlanErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/exception/PlanErrorCode.java
@@ -8,7 +8,23 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PlanErrorCode {
 
-  PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN-001", "일정이 존재하지 않습니다.");
+  // 기본 에러
+  PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN-001", "일정이 존재하지 않습니다."),
+
+  // 인원수 관련
+  INVALID_CAPACITY(HttpStatus.BAD_REQUEST, "PLAN-002", "모집 정원은 1명 이상이어야 합니다."),
+  INVALID_ATTENDEE_COUNT(HttpStatus.BAD_REQUEST, "PLAN-003", "참석자 수는 0명 이상이어야 합니다."),
+  ATTENDEE_EXCEEDS_CAPACITY(HttpStatus.BAD_REQUEST, "PLAN-004", "참석자 수가 모집 정원을 초과할 수 없습니다."),
+  PLAN_FULL(HttpStatus.BAD_REQUEST, "PLAN-005", "일정이 가득 찼습니다. 더 이상 참석할 수 없습니다."),
+  NO_ATTENDEE_TO_REMOVE(HttpStatus.BAD_REQUEST, "PLAN-006", "참석 취소할 인원이 없습니다."),
+
+  // 시간 관련
+  TIME_REQUIRED(HttpStatus.BAD_REQUEST, "PLAN-007", "시작시간과 종료시간은 필수입니다."),
+  INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "PLAN-008", "종료시간은 시작시간보다 늦어야 합니다."),
+
+  // 좌표 관련
+  COORDINATES_REQUIRED(HttpStatus.BAD_REQUEST, "PLAN-009", "위도와 경도는 필수입니다."),
+  INVALID_COORDINATE(HttpStatus.BAD_REQUEST, "PLAN-010", "좌표 값이 범위를 벗어났습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanServiceImpl.java
@@ -35,8 +35,11 @@ public class PlanServiceImpl implements PlanService {
                     .title(planRequestDto.title())
                     .description(planRequestDto.description())
                     .capacity(planRequestDto.capacity())
+                    .attendee(planRequestDto.attendee())
                     .startTime(planRequestDto.startTime())
                     .endTime(planRequestDto.endTime())
+                    .latitude(planRequestDto.latitude())
+                    .longitude(planRequestDto.longitude())
                     .build();
 
     Plan saved = planRepository.save(plan);
@@ -92,10 +95,13 @@ public class PlanServiceImpl implements PlanService {
         plan.getTitle(),
         plan.getDescription(),
         plan.getCapacity(),
+        plan.getAttendee(),
         plan.getStartTime(),
         plan.getEndTime(),
         plan.getCreatedAt(),
-        plan.getUpdatedAt()
+        plan.getUpdatedAt(),
+        plan.getLatitude(),
+        plan.getLongitude()
     );
   }
 }


### PR DESCRIPTION
- close #99 

1. 위도, 경도, 참여인원 수를 추가했습니다
<img width="1020" height="1038" alt="image" src="https://github.com/user-attachments/assets/ce9aeb8a-47e9-4edd-955a-4028facbb586" />
-> 예외처리랑 에러코드도 추가해놨습니다.

참여인원수는 출석체크 기능과 연관되기 때문에
출석체크랑 연결되는 메소드들을 미리 추가해놔서 이거랑 연결지으면서 구현하면 될 것 같습니다.(increaseAttendee, decreaseAttendee)

API 명세서 및 에러코드 수정했습니다.
(https://www.notion.so/teamsparta/2442dc3ef51481a3afbdf4caa9bc0b87)