### PR TITLE
feat: 게시글 댓글(Comment) CRUD 기능 구현 완료

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/comment/controller/CommentController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/controller/CommentController.java
@@ -1,17 +1,19 @@
 package com.kakaotechcampus.team16be.comment.controller;
 
+import com.kakaotechcampus.team16be.comment.domain.Comment;
+import com.kakaotechcampus.team16be.comment.dto.CommentIdResponse;
 import com.kakaotechcampus.team16be.comment.dto.CommentRequest;
 import com.kakaotechcampus.team16be.comment.dto.CommentResponse;
-import com.kakaotechcampus.team16be.comment.dto.GetCommentsResponse;
+import com.kakaotechcampus.team16be.comment.dto.CommentUpdateRequest;
 import com.kakaotechcampus.team16be.comment.service.CommentService;
 import com.kakaotechcampus.team16be.common.annotation.LoginUser;
 import com.kakaotechcampus.team16be.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,34 +23,56 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    @Operation(summary = "댓글 조회", description = "특정 게시글의 댓글 목록을 조회합니다. 부모 댓글 ID를 지정하면 대댓글 조회도 가능합니다.")
-    @GetMapping("/groups/{groupId}/posts/{postId}/comments")
-    public ResponseEntity<GetCommentsResponse> getComments(@PathVariable Long postId,
-                                                         @RequestParam(required = false) Long parentId,
-                                                         @RequestParam(required = false) Long cursor,
-                                                         @RequestParam(defaultValue = "10") int limit) {
-        return ResponseEntity.ok(commentService.getComments(postId, parentId, cursor, limit));
+    @Operation(summary = "부모 댓글 작성", description = "부모 댓글을 작성합니다.(대댓글 X)")
+    @PostMapping("/comments")
+    public ResponseEntity<CommentIdResponse> createParentComment(
+            @LoginUser User user,
+            @RequestBody CommentRequest commentRequest
+    ) {
+        Long commentId= commentService.createParentComment(user, commentRequest);
+        return ResponseEntity.ok(CommentIdResponse.from(commentId));
     }
 
-    @Operation(summary = "댓글 작성", description = "특정 게시글에 댓글을 작성합니다.")
-    @PostMapping("/groups/{groupId}/posts/{postId}/comments")
-    public ResponseEntity<CommentResponse> createComment(@PathVariable Long postId,
-                                                       @RequestBody CommentRequest request,
-                                                       @LoginUser User user) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(commentService.createComment(postId, user.getId(), request));
+    @Operation(summary = "대댓글 작성", description = "부모댓글에 대댓글을 작성합니다.")
+    @PostMapping("/comments/reply")
+    public ResponseEntity<CommentIdResponse> createChildComment(
+            @LoginUser User user,
+            @RequestBody CommentRequest commentRequest
+    ) {
+        Long commentId = commentService.createChildComment(user, commentRequest);
+        return ResponseEntity.ok(CommentIdResponse.from(commentId));
     }
 
-    @Operation(summary = "댓글 수정", description = "작성한 댓글을 수정합니다.")
-    @PatchMapping("/groups/{groupId}/posts/{postId}/comments/{commentId}")
-    public ResponseEntity<CommentResponse> updateComment(@PathVariable Long commentId, 
-                                                       @RequestBody CommentRequest request) {
-        return ResponseEntity.ok(commentService.updateComment(commentId, request));
+    @Operation(summary = "특정 게시글의 댓글 전부 조회", description = "특정 게시글의 모든 댓글을 조회합니다.")
+    @GetMapping("/posts/{postId}/comments")
+    public ResponseEntity<List<CommentResponse>> getAllComments(
+            @PathVariable Long postId
+    ) {
+        List<Comment> comments = commentService.getCommentsByPostId(postId);
+        return ResponseEntity.ok(CommentResponse.from(comments));
     }
 
-    @Operation(summary = "댓글 삭제", description = "작성한 댓글을 삭제합니다.")
-    @DeleteMapping("/groups/{groupId}/posts/{postId}/comments/{commentId}")
-    public ResponseEntity<Void> deleteComment(@PathVariable Long commentId) {
-        commentService.deleteComment(commentId);
+    @Operation(summary = "댓글 수정", description = "특정 댓글을 수정합니다.")
+    @PutMapping("/comments")
+    public ResponseEntity<CommentIdResponse> updateComment(
+            @LoginUser User user,
+            @RequestBody CommentUpdateRequest commentUpdateRequest
+    ) {
+        Long commentId = commentService.updateComment(user, commentUpdateRequest);
+        return ResponseEntity.ok(CommentIdResponse.from(commentId));
+    }
+
+    @Operation(summary = "댓글 삭제", description = "특정 댓글을 삭제합니다.")
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @LoginUser User user,
+            @PathVariable Long commentId
+    ) {
+        commentService.deleteComment(user, commentId);
         return ResponseEntity.noContent().build();
     }
+
 }
+    
+
+

--- a/src/main/java/com/kakaotechcampus/team16be/comment/domain/Comment.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/domain/Comment.java
@@ -1,15 +1,23 @@
 package com.kakaotechcampus.team16be.comment.domain;
 
+import com.kakaotechcampus.team16be.common.BaseEntity;
 import com.kakaotechcampus.team16be.user.domain.User;
 import com.kakaotechcampus.team16be.post.domain.Post;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
-@NoArgsConstructor
-public class Comment {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -26,16 +34,36 @@ public class Comment {
 
     @ManyToOne
     @JoinColumn(name = "parent_id")
-    private Comment parent;
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    private Comment parentComment;
 
-    public Comment(String content, Post post, User user, Comment parent) {
+    @OneToMany(mappedBy = "parentComment")
+    private List<Comment> childComments = new ArrayList<>();
+
+    @Builder
+    public Comment(String content, Post post, User user, Comment parentComment) {
         this.content = content;
         this.post = post;
         this.user = user;
-        this.parent = parent;
+        this.parentComment = parentComment;
     }
 
-    public void update(String content) {
+    public static Comment createComment(String content, Post post, User user, Comment parentComment) {
+        return Comment.builder()
+                .content(content)
+                .post(post)
+                .user(user)
+                .parentComment(parentComment)
+                .build();
+    }
+
+
+    public void updateContent(String content) {
         this.content = content;
+    }
+
+
+    public void updateParentCommentNull() {
+        this.parentComment = null;
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/comment/dto/CommentIdResponse.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/dto/CommentIdResponse.java
@@ -1,0 +1,9 @@
+package com.kakaotechcampus.team16be.comment.dto;
+
+public record CommentIdResponse(
+        Long commentId
+) {
+    public static CommentIdResponse from(Long commentId) {
+        return new CommentIdResponse(commentId);
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/comment/dto/CommentRequest.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/dto/CommentRequest.java
@@ -1,4 +1,9 @@
 package com.kakaotechcampus.team16be.comment.dto;
 
-public record CommentRequest(String content, Long parentId) {
+public record CommentRequest(
+        Long groupId,
+        Long postId,
+        String content,
+        Long parentId
+) {
 }

--- a/src/main/java/com/kakaotechcampus/team16be/comment/dto/CommentResponse.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/dto/CommentResponse.java
@@ -2,8 +2,26 @@ package com.kakaotechcampus.team16be.comment.dto;
 
 import com.kakaotechcampus.team16be.comment.domain.Comment;
 
-public record CommentResponse(Long id, String content) {
-    public static CommentResponse from(Comment comment) {
-        return new CommentResponse(comment.getId(), comment.getContent());
+import java.util.List;
+
+public record CommentResponse(
+        Long commentId,
+        String userNickname,
+        String content,
+        String createdAt,
+        String updatedAt,
+        Long parentCommentId
+) {
+    public static List<CommentResponse> from(List<Comment> comments) {
+        return comments.stream()
+                .map(comment -> new CommentResponse(
+                        comment.getId(),
+                        comment.getUser().getNickname(),
+                        comment.getContent(),
+                        comment.getCreatedAt().toString(),
+                        comment.getUpdatedAt().toString(),
+                        comment.getParentComment() != null ? comment.getParentComment().getId() : null
+                ))
+                .toList();
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/comment/dto/CommentUpdateRequest.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/dto/CommentUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.kakaotechcampus.team16be.comment.dto;
+
+
+public record CommentUpdateRequest(
+        Long commentId,
+        String content
+) {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/comment/dto/GetCommentsResponse.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/dto/GetCommentsResponse.java
@@ -1,6 +1,0 @@
-package com.kakaotechcampus.team16be.comment.dto;
-
-import java.util.List;
-
-public record GetCommentsResponse(List<CommentResponse> items, Long nextCursor) {
-}

--- a/src/main/java/com/kakaotechcampus/team16be/comment/exception/CommentErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/exception/CommentErrorCode.java
@@ -1,0 +1,17 @@
+package com.kakaotechcampus.team16be.comment.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommentErrorCode {
+    COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "COMMENT-001", "해당 댓글을 찾을 수 없습니다."),
+    COMMENT_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "COMMENT-002", "댓글에 대한 권한이 없습니다.");
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/kakaotechcampus/team16be/comment/exception/CommentException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/exception/CommentException.java
@@ -1,0 +1,15 @@
+package com.kakaotechcampus.team16be.comment.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CommentException extends RuntimeException {
+    private final CommentErrorCode errorCode;
+
+    @Override
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/comment/repository/CommentRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/repository/CommentRepository.java
@@ -1,13 +1,18 @@
 package com.kakaotechcampus.team16be.comment.repository;
 
 import com.kakaotechcampus.team16be.comment.domain.Comment;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
+import com.kakaotechcampus.team16be.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
+
+@Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    @Query("SELECT c FROM Comment c WHERE c.post.id = :postId AND ((:parentId IS NULL AND c.parent IS NULL) OR (c.parent.id = :parentId)) AND (:cursor IS NULL OR c.id > :cursor) ORDER BY c.id ASC")
-    Slice<Comment> findByPostIdAndParentIdWithCursor(@Param("postId") Long postId, @Param("parentId") Long parentId, @Param("cursor") Long cursor, Pageable pageable);
+
+    Optional<Comment> findById(Long id);
+
+    List<Comment> findAllByPost(Post post);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/comment/service/CommentService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/service/CommentService.java
@@ -2,56 +2,19 @@ package com.kakaotechcampus.team16be.comment.service;
 
 import com.kakaotechcampus.team16be.comment.domain.Comment;
 import com.kakaotechcampus.team16be.comment.dto.CommentRequest;
-import com.kakaotechcampus.team16be.comment.dto.CommentResponse;
-import com.kakaotechcampus.team16be.comment.dto.GetCommentsResponse;
-import com.kakaotechcampus.team16be.comment.repository.CommentRepository;
+import com.kakaotechcampus.team16be.comment.dto.CommentUpdateRequest;
 import com.kakaotechcampus.team16be.user.domain.User;
-import com.kakaotechcampus.team16be.user.repository.UserRepository;
-import com.kakaotechcampus.team16be.post.domain.Post;
-import com.kakaotechcampus.team16be.post.repository.PostRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.stream.Collectors;
+import java.util.List;
 
-@Service
-@RequiredArgsConstructor
-@Transactional
-public class CommentService {
+public interface CommentService {
+    Long createParentComment(User user,CommentRequest commentRequest);
 
-    private final CommentRepository commentRepository;
-    private final PostRepository postRepository;
-    private final UserRepository userRepository;
+    Long createChildComment(User user,CommentRequest commentRequest);
 
-    public GetCommentsResponse getComments(Long postId, Long parentId, Long cursor, int limit) {
-        PageRequest pageRequest = PageRequest.of(0, limit);
-        Slice<Comment> comments = commentRepository.findByPostIdAndParentIdWithCursor(postId, parentId, cursor, pageRequest);
-        Long nextCursor = comments.hasNext() ? comments.getContent().get(limit - 1).getId() : null;
-        return new GetCommentsResponse(comments.getContent().stream().map(CommentResponse::from).collect(Collectors.toList()), nextCursor);
-    }
+    List<Comment> getCommentsByPostId(Long postId);
 
-    public CommentResponse createComment(Long postId, Long memberId, CommentRequest request) {
-        Post post = postRepository.findById(postId).orElseThrow(() -> new RuntimeException("Post not found"));
-        User user = userRepository.findById(memberId).orElseThrow(() -> new RuntimeException("User not found"));
-        Comment parent = null;
-        if (request.parentId() != null) {
-            parent = commentRepository.findById(request.parentId()).orElseThrow(() -> new RuntimeException("Parent comment not found"));
-        }
-        Comment comment = new Comment(request.content(), post, user, parent);
-        commentRepository.save(comment);
-        return CommentResponse.from(comment);
-    }
+    Long updateComment(User user, CommentUpdateRequest commentUpdateRequest);
 
-    public CommentResponse updateComment(Long commentId, CommentRequest request) {
-        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new RuntimeException("Comment not found"));
-        comment.update(request.content());
-        return CommentResponse.from(comment);
-    }
-
-    public void deleteComment(Long commentId) {
-        commentRepository.deleteById(commentId);
-    }
+    void deleteComment(User user, Long commentId);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/service/CommentServiceImpl.java
@@ -1,0 +1,91 @@
+package com.kakaotechcampus.team16be.comment.service;
+
+import com.kakaotechcampus.team16be.comment.domain.Comment;
+import com.kakaotechcampus.team16be.comment.dto.CommentRequest;
+import com.kakaotechcampus.team16be.comment.dto.CommentUpdateRequest;
+import com.kakaotechcampus.team16be.comment.exception.CommentErrorCode;
+import com.kakaotechcampus.team16be.comment.exception.CommentException;
+import com.kakaotechcampus.team16be.comment.repository.CommentRepository;
+import com.kakaotechcampus.team16be.post.domain.Post;
+import com.kakaotechcampus.team16be.post.service.PostService;
+import com.kakaotechcampus.team16be.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostService postService;
+
+
+    @Transactional
+    @Override
+    public Long createParentComment(User user, CommentRequest commentRequest) {
+        Post post = postService.findById(commentRequest.postId());
+
+        Comment parentComment = Comment.createComment(commentRequest.content(), post, user, null);
+        commentRepository.save(parentComment);
+        return parentComment.getId();
+    }
+
+    @Override
+    @Transactional
+    public Long createChildComment(User user,CommentRequest commentRequest) {
+        Post post = postService.findById(commentRequest.postId());
+
+        Comment comment = findById(commentRequest.parentId());
+
+        Comment childComment = Comment.createComment(commentRequest.content(), post, user, comment);
+
+        return commentRepository.save(childComment).getId();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Comment> getCommentsByPostId(Long postId) {
+        Post post = postService.findById(postId);
+        return commentRepository.findAllByPost(post);
+    }
+
+    private Comment findById(Long id) {
+        return commentRepository.findById(id)
+                .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
+    }
+
+    @Override
+    @Transactional
+    public Long updateComment(User user, CommentUpdateRequest commentUpdateRequest) {
+        Comment comment = findById(commentUpdateRequest.commentId());
+        hasAuthority(user, comment);
+
+        comment.updateContent(commentUpdateRequest.content());
+
+        return comment.getId();
+    }
+
+    private static void hasAuthority(User user, Comment comment) {
+        if (!comment.getUser().getId().equals(user.getId())) {
+            throw new CommentException(CommentErrorCode.COMMENT_NOT_AUTHORIZED);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void deleteComment(User user, Long commentId) {
+        Comment comment = findById(commentId);
+        hasAuthority(user, comment);
+
+        if (comment.getParentComment() == null) {
+            for (Comment child : comment.getChildComments()) {
+                child.updateParentCommentNull();
+            }
+        }
+        commentRepository.delete(comment);
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
- close #87 

## 내용
#### 게시글 댓글 관련 CRUD 기능을 구현 완료하였습니다. 핵심 구현 사항은 전체적으로 다음과 같습니다.
- 부모 댓글 작성(Create)
- 대댓글 작성(Create)
- 특정 게시글 댓글 전체 조회(Read)
- 댓글 수정(Update)
- 댓글 삭제(Delete)
- DTO(CommentRequest, CommentUpdateRequest, CommentResponse, CommentIdResponse) 활용
- @LoginUser를 통한 사용자 인증 정보 연동
- Swagger @Operation과 @Tag로 API 문서화

#### POSTMAN을 통한 API 테스트는 전부 완료하였습니다.