### PR TITLE
refactor: 예외 통합 구조화 및 BaseException 적용

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/auth/exception/JwtErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/exception/JwtErrorCode.java
@@ -1,12 +1,13 @@
 package com.kakaotechcampus.team16be.auth.exception;
 
+import com.kakaotechcampus.team16be.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
-@RequiredArgsConstructor
 @Getter
-public enum JwtErrorCode {
+@RequiredArgsConstructor
+public enum JwtErrorCode implements ErrorCode {
     // 401 Unauthorized
     WRONG_HEADER_TOKEN(HttpStatus.UNAUTHORIZED,"AUTH-001", "잘못된 토큰입니다."),
 

--- a/src/main/java/com/kakaotechcampus/team16be/auth/exception/JwtException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/exception/JwtException.java
@@ -1,14 +1,29 @@
 package com.kakaotechcampus.team16be.auth.exception;
 
+import com.kakaotechcampus.team16be.common.exception.BaseException;
 import lombok.Getter;
 
 @Getter
-public class JwtException extends RuntimeException {
+public class JwtException extends BaseException {
 
     private final JwtErrorCode errorCode;
 
     public JwtException(JwtErrorCode errorCode) {
-        super(errorCode.getMessage());
         this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+
+    @Override
+    public String getCode() {
+        return errorCode.getCode();
+    }
+
+    @Override
+    public int getStatus() {
+        return errorCode.getStatus().value();
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/auth/exception/KakaoErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/exception/KakaoErrorCode.java
@@ -1,12 +1,13 @@
 package com.kakaotechcampus.team16be.auth.exception;
 
+import com.kakaotechcampus.team16be.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
-@RequiredArgsConstructor
 @Getter
-public enum KakaoErrorCode {
+@RequiredArgsConstructor
+public enum KakaoErrorCode implements ErrorCode {
 
     // 500 INTERNAL_SERVER_ERROR
     TOKEN_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"AUTH-003", "카카오 토큰 요청에 실패했습니다."),

--- a/src/main/java/com/kakaotechcampus/team16be/auth/exception/KakaoException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/exception/KakaoException.java
@@ -1,14 +1,29 @@
 package com.kakaotechcampus.team16be.auth.exception;
 
+import com.kakaotechcampus.team16be.common.exception.BaseException;
 import lombok.Getter;
 
 @Getter
-public class KakaoException extends RuntimeException {
+public class KakaoException extends BaseException {
 
     private final KakaoErrorCode errorCode;
 
     public KakaoException(KakaoErrorCode errorCode) {
-        super(errorCode.getMessage());
         this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+
+    @Override
+    public String getCode() {
+        return errorCode.getCode();
+    }
+
+    @Override
+    public int getStatus() {
+        return errorCode.getStatus().value();
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/comment/exception/CommentErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/exception/CommentErrorCode.java
@@ -7,9 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum CommentErrorCode {
+
     COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "COMMENT-001", "해당 댓글을 찾을 수 없습니다."),
     COMMENT_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "COMMENT-002", "댓글에 대한 권한이 없습니다.");
-
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/kakaotechcampus/team16be/comment/exception/CommentException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/exception/CommentException.java
@@ -1,15 +1,29 @@
 package com.kakaotechcampus.team16be.comment.exception;
 
+import com.kakaotechcampus.team16be.common.exception.BaseException;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
-public class CommentException extends RuntimeException {
+public class CommentException extends BaseException {
+
     private final CommentErrorCode errorCode;
+
+    public CommentException(CommentErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
 
     @Override
     public String getMessage() {
         return errorCode.getMessage();
+    }
+
+    @Override
+    public String getCode() {
+        return errorCode.getCode();
+    }
+
+    @Override
+    public int getStatus() {
+        return errorCode.getStatus().value();
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/common/exception/BaseException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/common/exception/BaseException.java
@@ -1,0 +1,10 @@
+package com.kakaotechcampus.team16be.common.exception;
+
+public abstract class BaseException extends RuntimeException {
+
+    public abstract String getMessage();
+
+    public abstract String getCode();
+
+    public abstract int getStatus();
+}

--- a/src/main/java/com/kakaotechcampus/team16be/common/exception/ErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/common/exception/ErrorCode.java
@@ -1,0 +1,12 @@
+package com.kakaotechcampus.team16be.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    String getMessage();
+
+    String getCode();
+
+    HttpStatus getStatus();
+}

--- a/src/main/java/com/kakaotechcampus/team16be/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakaotechcampus/team16be/common/exception/GlobalExceptionHandler.java
@@ -1,14 +1,5 @@
 package com.kakaotechcampus.team16be.common.exception;
 
-import com.kakaotechcampus.team16be.auth.exception.JwtException;
-import com.kakaotechcampus.team16be.auth.exception.KakaoException;
-import com.kakaotechcampus.team16be.comment.exception.CommentException;
-import com.kakaotechcampus.team16be.groundrule.exception.GroundRuleException;
-import com.kakaotechcampus.team16be.group.exception.GroupException;
-import com.kakaotechcampus.team16be.like.exception.LikeException;
-import com.kakaotechcampus.team16be.post.exception.PostException;
-import com.kakaotechcampus.team16be.report.exception.ReportException;
-import com.kakaotechcampus.team16be.user.exception.UserException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -16,80 +7,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    // JWT 관련 예외
-    @ExceptionHandler(JwtException.class)
-    public ResponseEntity<ErrorResponseDto> handleJwtException(JwtException e) {
-        return buildErrorResponse(e.getErrorCode().getMessage(),
-                e.getErrorCode().getCode(),
-                e.getErrorCode().getStatus().value());
-    }
-
-    // Kakao 관련 예외
-    @ExceptionHandler(KakaoException.class)
-    public ResponseEntity<ErrorResponseDto> handleKakaoException(KakaoException e) {
-        return buildErrorResponse(e.getErrorCode().getMessage(),
-                e.getErrorCode().getCode(),
-                e.getErrorCode().getStatus().value());
-    }
-
-    // User 예외
-    @ExceptionHandler(UserException.class)
-    public ResponseEntity<ErrorResponseDto> handleUserException(UserException e) {
-        return buildErrorResponse(e.getErrorCode().getMessage(),
-                e.getErrorCode().getCode(),
-                e.getErrorCode().getStatus().value());
-    }
-
-    // Report 예외
-    @ExceptionHandler(ReportException.class)
-    public ResponseEntity<ErrorResponseDto> handleReportException(ReportException e) {
-        return buildErrorResponse(e.getReportErrorCode().getMessage(),
-                e.getReportErrorCode().getCode(),
-                e.getReportErrorCode().getStatus().value());
-    }
-
-    // Group 예외
-    @ExceptionHandler(GroupException.class)
-    public ResponseEntity<ErrorResponseDto> handleGroupException(GroupException e) {
-        return buildErrorResponse(e.getGroupErrorCode().getMessage(),
-                e.getGroupErrorCode().getCode(),
-                e.getGroupErrorCode().getStatus().value());
-    }
-
-    // GroundRule 예외
-    @ExceptionHandler(GroundRuleException.class)
-    public ResponseEntity<ErrorResponseDto> handleGroundRuleException(GroundRuleException e) {
-        return buildErrorResponse(e.getErrorCode().getMessage(),
-                e.getErrorCode().getCode(),
-                e.getErrorCode().getStatus().value());
-    }
-
-    // Comment 예외
-    @ExceptionHandler(CommentException.class)
-    public ResponseEntity<ErrorResponseDto> handleCommentException(CommentException e) {
-        return buildErrorResponse(e.getErrorCode().getMessage(),
-                e.getErrorCode().getCode(),
-                e.getErrorCode().getStatus().value());
-    }
-
-    // Post 예외
-    @ExceptionHandler(PostException.class)
-    public ResponseEntity<ErrorResponseDto> handlePostException(PostException e) {
-        return buildErrorResponse(e.getErrorCode().getMessage(),
-                e.getErrorCode().getCode(),
-                e.getErrorCode().getStatus().value());
-    }
-
-    // Like 예외
-    @ExceptionHandler(LikeException.class)
-    public ResponseEntity<ErrorResponseDto> handleLikeException(LikeException e) {
-        return buildErrorResponse(e.getErrorCode().getMessage(),
-                e.getErrorCode().getCode(),
-                e.getErrorCode().getStatus().value());
-    }
-
-    private ResponseEntity<ErrorResponseDto> buildErrorResponse(String message, String code, int status) {
-        return ResponseEntity.status(status)
-                .body(new ErrorResponseDto(message, code, status));
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ErrorResponseDto> handleBaseException(BaseException e) {
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(new ErrorResponseDto(e.getMessage(), e.getCode(), e.getStatus()));
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/groundrule/exception/GroundRuleErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groundrule/exception/GroundRuleErrorCode.java
@@ -1,12 +1,13 @@
 package com.kakaotechcampus.team16be.groundrule.exception;
 
+import com.kakaotechcampus.team16be.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum GroundRuleErrorCode {
+public enum GroundRuleErrorCode implements ErrorCode {
 
   RULE_NOT_FOUND(HttpStatus.NOT_FOUND, "RULE-001", "해당 룰이 존재하지 않습니다."),
   RULE_NOT_ADD(HttpStatus.BAD_REQUEST, "RULE-002", "모임 당 룰의 최대 개수는 5개입니다.");

--- a/src/main/java/com/kakaotechcampus/team16be/groundrule/exception/GroundRuleException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groundrule/exception/GroundRuleException.java
@@ -1,14 +1,29 @@
 package com.kakaotechcampus.team16be.groundrule.exception;
 
+import com.kakaotechcampus.team16be.common.exception.BaseException;
 import lombok.Getter;
 
 @Getter
-public class GroundRuleException extends RuntimeException {
+public class GroundRuleException extends BaseException {
 
   private final GroundRuleErrorCode errorCode;
 
   public GroundRuleException(GroundRuleErrorCode errorCode) {
-    super(errorCode.getMessage());
     this.errorCode = errorCode;
+  }
+
+  @Override
+  public String getMessage() {
+    return errorCode.getMessage();
+  }
+
+  @Override
+  public String getCode() {
+    return errorCode.getCode();
+  }
+
+  @Override
+  public int getStatus() {
+    return errorCode.getStatus().value();
   }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/group/exception/GroupErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/exception/GroupErrorCode.java
@@ -1,12 +1,13 @@
 package com.kakaotechcampus.team16be.group.exception;
 
+import com.kakaotechcampus.team16be.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum GroupErrorCode {
+public enum GroupErrorCode implements ErrorCode {
 
     GROUP_NAME_DUPLICATE(HttpStatus.CONFLICT, "GROUP-001", "해당 모임의 이름은 이미 존재합니다."),
     WRONG_GROUP_NAME(HttpStatus.BAD_REQUEST, "GROUP-002", "올바르지 않은 모임 이름입니다."),
@@ -18,9 +19,7 @@ public enum GroupErrorCode {
     GROUP_NO_FILENAME(HttpStatus.BAD_REQUEST, "GROUP-007", "해당 파일이 없습니다."),
     WRONG_GROUP_ACCESS(HttpStatus.FORBIDDEN, "GROUP-009", "잘못된 그룹 접근입니다.");
 
-
     private final HttpStatus status;
     private final String code;
     private final String message;
-
 }

--- a/src/main/java/com/kakaotechcampus/team16be/group/exception/GroupException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/exception/GroupException.java
@@ -1,14 +1,29 @@
 package com.kakaotechcampus.team16be.group.exception;
 
+import com.kakaotechcampus.team16be.common.exception.BaseException;
 import lombok.Getter;
 
 @Getter
-public class GroupException extends RuntimeException {
+public class GroupException extends BaseException {
 
-    private final GroupErrorCode groupErrorCode;
+    private final GroupErrorCode errorCode;
 
-    public GroupException(GroupErrorCode groupErrorCode) {
-        super(groupErrorCode.getMessage());
-        this.groupErrorCode = groupErrorCode;
+    public GroupException(GroupErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+
+    @Override
+    public String getCode() {
+        return errorCode.getCode();
+    }
+
+    @Override
+    public int getStatus() {
+        return errorCode.getStatus().value();
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/exception/GroupMemberErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/exception/GroupMemberErrorCode.java
@@ -1,12 +1,13 @@
 package com.kakaotechcampus.team16be.groupMember.exception;
 
+import com.kakaotechcampus.team16be.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum GroupMemberErrorCode {
+public enum GroupMemberErrorCode implements ErrorCode {
 
     GROUP_MEMBER_ALREADY_EXIST(HttpStatus.CONFLICT, "GROUP_MEMBER-001", "이미 그룹에 속해있는 멤버입니다."),
     GROUP_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP_MEMBER-002", "해당 유저는 그룹의 멤버가 아닙니다."),
@@ -18,7 +19,6 @@ public enum GroupMemberErrorCode {
     MEMBER_ALREADY_BANNED(HttpStatus.BAD_REQUEST, "GROUP_MEMBER-008", "해당 유저는 이미 강퇴 당한 유저입니다."),
     MEMBER_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "GROUP_MEMBER-009", "해당 유저는 가입 신청 취소할 수 없는 상태입니다."),
     MEMBER_NOT_PENDING(HttpStatus.BAD_REQUEST, "GROUP_MEMBER-010", "해당 유저는 가입 승인할 수 없는 상태입니다.");
-
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/exception/GroupMemberException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/exception/GroupMemberException.java
@@ -1,15 +1,29 @@
 package com.kakaotechcampus.team16be.groupMember.exception;
 
-
+import com.kakaotechcampus.team16be.common.exception.BaseException;
 import lombok.Getter;
 
 @Getter
-public class GroupMemberException extends RuntimeException {
+public class GroupMemberException extends BaseException {
 
     private final GroupMemberErrorCode errorCode;
 
     public GroupMemberException(GroupMemberErrorCode errorCode) {
-        super(errorCode.getMessage());
         this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+
+    @Override
+    public String getCode() {
+        return errorCode.getCode();
+    }
+
+    @Override
+    public int getStatus() {
+        return errorCode.getStatus().value();
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/like/exception/LikeErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/like/exception/LikeErrorCode.java
@@ -1,12 +1,14 @@
 package com.kakaotechcampus.team16be.like.exception;
 
+import com.kakaotechcampus.team16be.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum LikeErrorCode {
+public enum LikeErrorCode implements ErrorCode {
+
     ALREADY_LIKED_POST(HttpStatus.BAD_REQUEST, "LIKE_01", "이미 좋아요를 눌렀습니다."),
     NOT_LIKED_POST(HttpStatus.BAD_REQUEST, "LIKE_02", "좋아요를 누르지 않은 게시물입니다.");
 

--- a/src/main/java/com/kakaotechcampus/team16be/like/exception/LikeException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/like/exception/LikeException.java
@@ -1,14 +1,29 @@
 package com.kakaotechcampus.team16be.like.exception;
 
+import com.kakaotechcampus.team16be.common.exception.BaseException;
 import lombok.Getter;
 
 @Getter
-public class LikeException extends RuntimeException {
+public class LikeException extends BaseException {
 
     private final LikeErrorCode errorCode;
 
     public LikeException(LikeErrorCode errorCode) {
-        super(errorCode.getMessage());
         this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+
+    @Override
+    public String getCode() {
+        return errorCode.getCode();
+    }
+
+    @Override
+    public int getStatus() {
+        return errorCode.getStatus().value();
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/plan/exception/PlanErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/exception/PlanErrorCode.java
@@ -1,12 +1,13 @@
 package com.kakaotechcampus.team16be.plan.exception;
 
+import com.kakaotechcampus.team16be.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum PlanErrorCode {
+public enum PlanErrorCode implements ErrorCode {
 
   // 기본 에러
   PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN-001", "일정이 존재하지 않습니다."),
@@ -26,7 +27,7 @@ public enum PlanErrorCode {
   COORDINATES_REQUIRED(HttpStatus.BAD_REQUEST, "PLAN-009", "위도와 경도는 필수입니다."),
   INVALID_COORDINATE(HttpStatus.BAD_REQUEST, "PLAN-010", "좌표 값이 범위를 벗어났습니다.");
 
-  private final HttpStatus httpStatus;
+  private final HttpStatus status;
   private final String code;
   private final String message;
 }

--- a/src/main/java/com/kakaotechcampus/team16be/plan/exception/PlanException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/exception/PlanException.java
@@ -1,14 +1,30 @@
 package com.kakaotechcampus.team16be.plan.exception;
 
+import com.kakaotechcampus.team16be.common.exception.BaseException;
 import lombok.Getter;
 
+
 @Getter
-public class PlanException extends RuntimeException {
+public class PlanException extends BaseException {
 
-    private final PlanErrorCode planErrorCode;
+    private final PlanErrorCode errorCode;
 
-    public PlanException(PlanErrorCode planErrorCode) {
-        super(planErrorCode.getMessage());
-        this.planErrorCode = planErrorCode;
+    public PlanException(PlanErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+
+    @Override
+    public String getCode() {
+        return errorCode.getCode();
+    }
+
+    @Override
+    public int getStatus() {
+        return errorCode.getStatus().value();
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/post/exception/PostErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/post/exception/PostErrorCode.java
@@ -1,15 +1,15 @@
 package com.kakaotechcampus.team16be.post.exception;
 
+import com.kakaotechcampus.team16be.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum PostErrorCode {
+public enum PostErrorCode implements ErrorCode {
 
     POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST-001", "해당 게시글을 찾을 수 없습니다.");
-
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/kakaotechcampus/team16be/post/exception/PostException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/post/exception/PostException.java
@@ -1,14 +1,29 @@
 package com.kakaotechcampus.team16be.post.exception;
 
+import com.kakaotechcampus.team16be.common.exception.BaseException;
 import lombok.Getter;
 
 @Getter
-public class PostException extends RuntimeException {
+public class PostException extends BaseException {
 
     private final PostErrorCode errorCode;
 
     public PostException(PostErrorCode errorCode) {
-        super(errorCode.getMessage());
         this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+
+    @Override
+    public String getCode() {
+        return errorCode.getCode();
+    }
+
+    @Override
+    public int getStatus() {
+        return errorCode.getStatus().value();
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/report/exception/ReportErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/report/exception/ReportErrorCode.java
@@ -1,12 +1,13 @@
 package com.kakaotechcampus.team16be.report.exception;
 
+import com.kakaotechcampus.team16be.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum ReportErrorCode {
+public enum ReportErrorCode implements ErrorCode {
 
   REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT-002", "해당 신고가 존재하지 않습니다.");
 

--- a/src/main/java/com/kakaotechcampus/team16be/report/exception/ReportException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/report/exception/ReportException.java
@@ -1,14 +1,29 @@
 package com.kakaotechcampus.team16be.report.exception;
 
+import com.kakaotechcampus.team16be.common.exception.BaseException;
 import lombok.Getter;
 
 @Getter
-public class ReportException extends RuntimeException {
+public class ReportException extends BaseException {
 
-  private final ReportErrorCode reportErrorCode;
+  private final ReportErrorCode errorCode;
 
-  public ReportException(ReportErrorCode reportErrorCode) {
-    super(reportErrorCode.getMessage());
-    this.reportErrorCode = reportErrorCode;
+  public ReportException(ReportErrorCode errorCode) {
+    this.errorCode = errorCode;
+  }
+
+  @Override
+  public String getMessage() {
+    return errorCode.getMessage();
+  }
+
+  @Override
+  public String getCode() {
+    return errorCode.getCode();
+  }
+
+  @Override
+  public int getStatus() {
+    return errorCode.getStatus().value();
   }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/review/common/exception/ReviewErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/common/exception/ReviewErrorCode.java
@@ -1,16 +1,15 @@
 package com.kakaotechcampus.team16be.review.common.exception;
 
+import com.kakaotechcampus.team16be.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum ReviewErrorCode {
+public enum ReviewErrorCode implements ErrorCode {
 
     ACTIVE_CANNOT_REVIEW(HttpStatus.FORBIDDEN, "REVIEW-001", "탈퇴한 회원에 대해서만 리뷰가 가능합니다.");
-
-
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/kakaotechcampus/team16be/review/common/exception/ReviewException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/review/common/exception/ReviewException.java
@@ -1,15 +1,29 @@
 package com.kakaotechcampus.team16be.review.common.exception;
 
-
+import com.kakaotechcampus.team16be.common.exception.BaseException;
 import lombok.Getter;
 
 @Getter
-public class ReviewException extends RuntimeException {
+public class ReviewException extends BaseException {
 
-    private final ReviewErrorCode reviewErrorCode;
+    private final ReviewErrorCode errorCode;
 
-    public ReviewException(ReviewErrorCode reviewErrorCode) {
-        super(reviewErrorCode.getMessage());
-        this.reviewErrorCode = reviewErrorCode;
+    public ReviewException(ReviewErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+
+    @Override
+    public String getCode() {
+        return errorCode.getCode();
+    }
+
+    @Override
+    public int getStatus() {
+        return errorCode.getStatus().value();
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/user/exception/UserErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/exception/UserErrorCode.java
@@ -1,17 +1,17 @@
 package com.kakaotechcampus.team16be.user.exception;
 
+import com.kakaotechcampus.team16be.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
-@RequiredArgsConstructor
 @Getter
-public enum UserErrorCode {
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND,"USER-005" ,"유저를 찾을 수 없습니다."),
     PROFILE_IMAGE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST,"USER-006", "이미 프로필 이미지가 존재합니다"),
     PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND,"USER-007", "프로필 이미지를 찾을 수 없습니다.");
-
 
     private final HttpStatus status; // HTTP 상태 코드
     private final String code; //사용자 정의 에러 코드

--- a/src/main/java/com/kakaotechcampus/team16be/user/exception/UserException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/exception/UserException.java
@@ -1,14 +1,29 @@
 package com.kakaotechcampus.team16be.user.exception;
 
+import com.kakaotechcampus.team16be.common.exception.BaseException;
 import lombok.Getter;
 
 @Getter
-public class UserException extends RuntimeException {
+public class UserException extends BaseException {
 
     private final UserErrorCode errorCode;
 
     public UserException(UserErrorCode errorCode) {
-        super(errorCode.getMessage());
         this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+
+    @Override
+    public String getCode() {
+        return errorCode.getCode();
+    }
+
+    @Override
+    public int getStatus() {
+        return errorCode.getStatus().value();
     }
 }


### PR DESCRIPTION
### 관련이슈
- close #108 

### 변경 사항
1. 모든 도메인 예외(BaseException 상속)
   - JwtException, KakaoException, CommentException, GroundRuleException,
     GroupException, GroupMemberException, LikeException, PlanException,
     PostException, ReportException, ReviewException, UserException
   - 공통 BaseException 상속
   - ErrorCode(enum) 기반 메시지/코드/HTTP 상태 관리

2. 공통 ErrorCode 인터페이스 추가
   - ErrorCode interface 생성
     - getMessage()
     - getCode()
     - getStatus()
   - 모든 도메인별 ErrorCode enum(UserErrorCode, PlanErrorCode, 등) implements ErrorCode

3. GlobalExceptionHandler 단일화
   - @ExceptionHandler(BaseException.class) 단일 핸들러로 모든 예외 처리
   - ResponseEntity<ErrorResponseDto> 반환
   - JSON 구조: { message, code, status }

### 개선 포인트
- 예외 구조 통합 → 중복 코드 제거
- 새로운 도메인 예외 추가 시 ErrorCode enum + Exception 클래스만 만들면 됨
- GlobalExceptionHandler 단일화로 유지보수 용이

이번 PR에서는 모든 도메인 예외를 BaseException 상속 + ErrorCode 기반으로 통합했습니다.
불필요한 복잡한 예외 처리 로직은 구현하지 않고, 실제 필요할 때만 확장 가능하도록
**YAGNI(You Aren’t Gonna Need It) 원칙**을 적용했습니다.