### PR TITLE
fix:순환 구조 문제 해결

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/aws/service/S3UploadPresignedUrlService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/service/S3UploadPresignedUrlService.java
@@ -7,18 +7,23 @@ import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.kakaotechcampus.team16be.aws.domain.ImageFileExtension;
 import com.kakaotechcampus.team16be.aws.domain.ImageUploadType;
 import com.kakaotechcampus.team16be.aws.dto.ImageUrlDto;
+import com.kakaotechcampus.team16be.group.domain.Group;
 import com.kakaotechcampus.team16be.group.service.GroupService;
 import com.kakaotechcampus.team16be.user.domain.User;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
+
 import java.net.URL;
 import java.util.Date;
 import java.util.UUID;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class S3UploadPresignedUrlService {
 
     @Value("${cloud.aws.s3.default-image-url}")
@@ -29,11 +34,6 @@ public class S3UploadPresignedUrlService {
 
     private final AmazonS3Client amazonS3Client;
     private final GroupService groupService;
-  
-    public S3UploadPresignedUrlService(AmazonS3Client amazonS3Client, @Lazy GroupService groupService) {
-        this.amazonS3Client = amazonS3Client;
-        this.groupService = groupService;
-    }
 
     public ImageUrlDto execute(
             Long userId, ImageFileExtension fileExtension, ImageUploadType type
@@ -128,6 +128,8 @@ public class S3UploadPresignedUrlService {
 
     public ImageUrlDto executePostImg(User user, Long groupId, Long postId, ImageFileExtension fileExtension) {
 
+        Group targetGroup = groupService.findGroupById(groupId);
+        targetGroup.checkLeader(user);
         String valueFileExtension = fileExtension.getUploadExtension();
         String valueType = String.valueOf(ImageUploadType.POST);
         String fileName = createPostFileName(groupId, postId, valueFileExtension, valueType);

--- a/src/main/java/com/kakaotechcampus/team16be/common/eventListener/ImageDeletedEvent.java
+++ b/src/main/java/com/kakaotechcampus/team16be/common/eventListener/ImageDeletedEvent.java
@@ -1,0 +1,4 @@
+package com.kakaotechcampus.team16be.common.eventListener;
+
+public record ImageDeletedEvent(String fileName) {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/common/eventListener/ImageEventListener.java
+++ b/src/main/java/com/kakaotechcampus/team16be/common/eventListener/ImageEventListener.java
@@ -1,0 +1,21 @@
+package com.kakaotechcampus.team16be.common.eventListener;
+
+import com.kakaotechcampus.team16be.aws.service.S3UploadPresignedUrlService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ImageEventListener {
+
+    private final S3UploadPresignedUrlService s3UploadPresignedUrlService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onImageDeleted(ImageDeletedEvent event) {
+        s3UploadPresignedUrlService.deleteImage(event.fileName());
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/group/controller/GroupController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/controller/GroupController.java
@@ -4,6 +4,7 @@ package com.kakaotechcampus.team16be.group.controller;
 import com.kakaotechcampus.team16be.common.annotation.LoginUser;
 import com.kakaotechcampus.team16be.group.domain.Group;
 import com.kakaotechcampus.team16be.group.dto.*;
+import com.kakaotechcampus.team16be.group.service.GroupFacade;
 import com.kakaotechcampus.team16be.group.service.GroupService;
 import com.kakaotechcampus.team16be.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,6 +24,7 @@ import java.util.List;
 public class GroupController {
 
     private final GroupService groupService;
+    private final GroupFacade groupFacade;
 
     @Operation(summary = "모임 생성", description = "새로운 모임을 생성합니다.")
     @PostMapping
@@ -34,14 +36,14 @@ public class GroupController {
     @Operation(summary = "모임 목록 조회", description = "모든 모임 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<List<ResponseGroupListDto>> getAllGroups() {
-        List<ResponseGroupListDto> result = groupService.getAllGroups();
+        List<ResponseGroupListDto> result = groupFacade.getGroups();
         return ResponseEntity.ok(result);
     }
 
     @Operation(summary = "모임 상세 조회", description = "특정 모임의 상세 정보를 조회합니다.")
     @GetMapping("/{groupId}")
     public ResponseEntity<ResponseSingleGroupDto> getGroup(@PathVariable("groupId") Long groupId) {
-        return ResponseEntity.ok(groupService.getGroup(groupId));
+        return ResponseEntity.ok(groupFacade.getGroup(groupId));
     }
 
     @Operation(summary = "모임 삭제", description = "특정 모임을 삭제합니다.")

--- a/src/main/java/com/kakaotechcampus/team16be/group/service/GroupFacade.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/service/GroupFacade.java
@@ -1,0 +1,37 @@
+package com.kakaotechcampus.team16be.group.service; // 편의상 같은 패키지에 생성
+
+import com.kakaotechcampus.team16be.aws.service.S3UploadPresignedUrlService;
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.group.dto.ResponseGroupListDto;
+import com.kakaotechcampus.team16be.group.dto.ResponseSingleGroupDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GroupFacade {
+
+    private final GroupService groupService;
+    private final S3UploadPresignedUrlService s3UploadPresignedUrlService;
+
+    @Transactional(readOnly = true)
+    public List<ResponseGroupListDto> getGroups() {
+        List<Group> findGroups = groupService.getAllGroups();
+
+        return findGroups.stream()
+                .map(group -> {
+                    String fullUrl = s3UploadPresignedUrlService.getPublicUrl(group.getCoverImageUrl());
+                    return ResponseGroupListDto.from(group, fullUrl);
+                }).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ResponseSingleGroupDto getGroup(Long groupId) {
+        Group targetGroup = groupService.findGroupById(groupId);
+        String fullUrl = s3UploadPresignedUrlService.getPublicUrl(targetGroup.getCoverImageUrl());
+        return ResponseSingleGroupDto.from(targetGroup, fullUrl);
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/group/service/GroupService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/service/GroupService.java
@@ -13,15 +13,13 @@ import java.util.List;
 public interface GroupService {
     Group createGroup(User user, CreateGroupDto createGroupDto);
 
-    List<ResponseGroupListDto> getAllGroups();
+    List<Group> getAllGroups();
 
     void deleteGroup(User user,Long groupId);
 
     Group updateGroup(User user, Long groupId, UpdateGroupDto updateGroupDto);
 
     Group findGroupById(Long groupId);
-
-    ResponseSingleGroupDto getGroup(Long groupId);
 
     Group updateGroupImage(User user, Long groupId, UpdateGroupDto updateGroupDto);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
@@ -1,10 +1,8 @@
 package com.kakaotechcampus.team16be.group.service;
 
-import com.kakaotechcampus.team16be.aws.service.S3UploadPresignedUrlService;
+import com.kakaotechcampus.team16be.common.eventListener.ImageDeletedEvent;
 import com.kakaotechcampus.team16be.group.domain.Group;
 import com.kakaotechcampus.team16be.group.dto.CreateGroupDto;
-import com.kakaotechcampus.team16be.group.dto.ResponseGroupListDto;
-import com.kakaotechcampus.team16be.group.dto.ResponseSingleGroupDto;
 import com.kakaotechcampus.team16be.group.dto.UpdateGroupDto;
 import com.kakaotechcampus.team16be.group.exception.GroupErrorCode;
 import com.kakaotechcampus.team16be.group.exception.GroupException;
@@ -14,29 +12,20 @@ import com.kakaotechcampus.team16be.user.exception.UserErrorCode;
 import com.kakaotechcampus.team16be.user.exception.UserException;
 import com.kakaotechcampus.team16be.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Lazy;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
 
+@RequiredArgsConstructor
 @Service
 public class GroupServiceImpl implements GroupService {
 
     private final GroupRepository groupRepository;
     private final UserRepository userRepository;
-    private final S3UploadPresignedUrlService s3UploadPresignedUrlService;
-
-    public GroupServiceImpl(
-            GroupRepository groupRepository,
-            S3UploadPresignedUrlService s3UploadPresignedUrlService,
-            UserRepository userRepository
-    ) {
-        this.groupRepository = groupRepository;
-        this.s3UploadPresignedUrlService = s3UploadPresignedUrlService;
-        this.userRepository = userRepository;
-    }
+    private final ApplicationEventPublisher eventPublisher;
 
 
     @Transactional
@@ -59,7 +48,7 @@ public class GroupServiceImpl implements GroupService {
 
     @Transactional(readOnly = true)
     @Override
-    public List<ResponseGroupListDto> getAllGroups() {
+    public List<Group> getAllGroups() {
 
         List<Group> findGroups = groupRepository.findAll();
 
@@ -67,11 +56,7 @@ public class GroupServiceImpl implements GroupService {
             throw new GroupException(GroupErrorCode.GROUP_CANNOT_FOUND);
         }
 
-        return findGroups.stream()
-                .map(group -> {
-                    String fullUrl = s3UploadPresignedUrlService.getPublicUrl(group.getCoverImageUrl());
-                    return ResponseGroupListDto.from(group, fullUrl);
-                }).toList();
+        return findGroups;
     }
 
 
@@ -108,15 +93,7 @@ public class GroupServiceImpl implements GroupService {
         return groupRepository.findById(groupId).orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_CANNOT_FOUND));
     }
 
-    @Override
-    public ResponseSingleGroupDto getGroup(Long groupId) {
-        Group targetGroup = findGroupById(groupId);
 
-        String fullUrl = s3UploadPresignedUrlService.getPublicUrl(targetGroup.getCoverImageUrl());
-
-        return ResponseSingleGroupDto.from(targetGroup, fullUrl);
-
-    }
     @Transactional
     @Override
     public Group updateGroupImage(User user, Long groupId, UpdateGroupDto UpdateGroupDto) {
@@ -130,8 +107,8 @@ public class GroupServiceImpl implements GroupService {
         targetGroup.changeCoverImage(updatedImgUrl);
 
         boolean isImageChanged = !Objects.equals(updatedImgUrl, oldImgUrl);
-        if (isImageChanged&&!oldImgUrl.isEmpty()) {
-            s3UploadPresignedUrlService.deleteImage(oldImgUrl);
+        if (isImageChanged && oldImgUrl != null && !oldImgUrl.isEmpty()) {
+            eventPublisher.publishEvent(new ImageDeletedEvent(oldImgUrl));
         }
 
         return targetGroup;


### PR DESCRIPTION
### 문제 상황

```
    public S3UploadPresignedUrlService(AmazonS3Client amazonS3Client, @Lazy GroupService groupService) {
        this.amazonS3Client = amazonS3Client;
        this.groupService = groupService;
    }
```

```

    private final GroupRepository groupRepository;
    private final UserRepository userRepository;
    private final S3UploadPresignedUrlService s3UploadPresignedUrlService;

    public GroupServiceImpl(
            GroupRepository groupRepository,
            S3UploadPresignedUrlService s3UploadPresignedUrlService,
            UserRepository userRepository
    ) {
        this.groupRepository = groupRepository;
        this.s3UploadPresignedUrlService = s3UploadPresignedUrlService;
        this.userRepository = userRepository;
    }
```

스프링 애플리케이션은 실행과 동시에 서비스 계층 Bean을 생성하고 이에 필요한 객체를 주입시켜줍니다. 
그런데 기존 코드를 보면 위와 같이 S3 서비스는 GroupService는 S3Service를, S3Service는 GroupService를 서로 주입이 필요한 상태이므로, 무한히 순환하는 순환참조 현상이 발생합니다.

그래서 기존 @Lazy를 사용하여, JPA의 지연 로딩과 같이 해당 서비스를 사용할 때 주입받는 형태로 구현해왔습니다. 하지만 이는 근본적인 해결 방식이 아니며,  추후에도 문제가 발생할확률이 높습니다.

### 해결방안
1. 퍼사드 패턴 사용
저희가 만든 GroupMember 도메인처럼 JPA 엔티티를 보통 N:M 양쪽 매핑하는 것을 지양합니다. 이 대신 중간 엔티티 테이블을 만들어서, N:1 1:M 이런식으로 사용하는데요. 이처럼 저 해당 서비스를 주입받는 퍼사드 서비스를 만들었습니다. 이를 통해 GroupService는 더 이상, S3를 주입받지 않아 순환 참조가 해결됩니다.
https://velog.io/@jay_be/Design-Pattern-%ED%8D%BC%EC%82%AC%EB%93%9C-%ED%8C%A8%ED%84%B4

2. 이벤트 리스너 사용
원래는 퍼사드 패턴만으로도 순환 참조 문제가 해결가능합니다. 하지만 저희가 이미지를 변경할 때, 기존 버킷의 있는 S3의 이미지를 삭제시키고, 새로운 이미지를 넣습니다. 하지만 이 과정에서 S3에는 반영이 됐지만, DB 오류때문에 롤백이 된다고 하면 문제가 발생합니다. 이를 해결하기 위해 이벤트 리스너를 사용했습니다.
ransactionPhase.AFTER_COMMIT를 통해 해당 이미지가 DB에 적용이 완료된 경우에만 deleteImage 메서드를 실행하게 되어 데이터 안정성을 보장받게 됩니다.


```
    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

    public void onImageDeleted(ImageDeletedEvent event) {

        s3UploadPresignedUrlService.deleteImage(event.fileName());

    }
```

- close #114 