### PR TITLE
feat: SSE 환경 구축 & 알림 도메인 구현 및 적용

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/controller/GroupMemberController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/controller/GroupMemberController.java
@@ -3,9 +3,7 @@ package com.kakaotechcampus.team16be.groupMember.controller;
 
 import com.kakaotechcampus.team16be.common.annotation.LoginUser;
 import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
-import com.kakaotechcampus.team16be.groupMember.dto.JoinRequestDto;
-import com.kakaotechcampus.team16be.groupMember.dto.RequestGroupMemberDto;
-import com.kakaotechcampus.team16be.groupMember.dto.ResponseGroupMemberDto;
+import com.kakaotechcampus.team16be.groupMember.dto.*;
 import com.kakaotechcampus.team16be.groupMember.service.GroupMemberService;
 import com.kakaotechcampus.team16be.groupMember.service.GroupMemberFacade;
 import com.kakaotechcampus.team16be.user.domain.User;
@@ -28,24 +26,24 @@ public class GroupMemberController {
 
     @Operation(summary = "그룹 가입 승인", description = "특정 유저를 그룹에 가입 승인합니다.")
     @PostMapping("/join")
-    public ResponseEntity<ResponseGroupMemberDto> joinGroup(@LoginUser User user, @RequestBody RequestGroupMemberDto requestGroupMemberDto) {
-        GroupMemberFacade.joinGroup(requestGroupMemberDto.groupId(), requestGroupMemberDto.userId(), user.getId());
+    public ResponseEntity<ResponseGroupMemberDto> joinGroup(@LoginUser User user, @RequestBody ApproveJoinRequestDto approveJoinRequestDto) {
+        GroupMemberFacade.joinGroup(approveJoinRequestDto.groupId(), approveJoinRequestDto.userId(), user.getId());
 
         return ResponseEntity.ok(ResponseGroupMemberDto.success(HttpStatus.CREATED, "해당 유저를 그룹에 가입 승인했습니다"));
     }
 
     @Operation(summary = "그룹 탈퇴", description = "로그인한 유저를 해당 그룹에서 탈퇴 처리합니다.")
     @PostMapping("/leave")
-    public ResponseEntity<ResponseGroupMemberDto> leaveGroup(@LoginUser User user, @RequestBody RequestGroupMemberDto requestGroupMemberDto) {
-        GroupMember groupMember = GroupMemberFacade.leaveGroup(requestGroupMemberDto.groupId(), user.getId());
+    public ResponseEntity<ResponseGroupMemberDto> leaveGroup(@LoginUser User user, @RequestBody LeaveGroupRequestDto leaveGroupRequestDto) {
+        GroupMember groupMember = GroupMemberFacade.leaveGroup(leaveGroupRequestDto.groupId(), user.getId());
 
         return ResponseEntity.ok(ResponseGroupMemberDto.success(HttpStatus.OK, groupMember.getUser().getNickname() + "가 그룹을 탈퇴했습니다."));
     }
 
     @Operation(summary = "그룹 강퇴", description = "특정 유저를 그룹에서 강제로 제거합니다.")
     @PostMapping("/banned")
-    public ResponseEntity<ResponseGroupMemberDto> bannedMember(@LoginUser User user, @RequestBody RequestGroupMemberDto requestGroupMemberDto) {
-        GroupMember groupMember = GroupMemberFacade.bannedGroup(requestGroupMemberDto.groupId(), requestGroupMemberDto.userId(), user);
+    public ResponseEntity<ResponseGroupMemberDto> bannedMember(@LoginUser User user, @RequestBody BanMemberRequestDto banMemberRequestDto) {
+        GroupMember groupMember = GroupMemberFacade.bannedGroup(banMemberRequestDto.groupId(), banMemberRequestDto.userId(), user);
 
 
         return ResponseEntity.ok(ResponseGroupMemberDto.success(HttpStatus.OK, groupMember.getUser().getNickname() + "가 그룹에서 강퇴당했습니다"));
@@ -53,23 +51,23 @@ public class GroupMemberController {
 
     @Operation(summary = "그룹 가입 신청 취소", description = "특정 유저가 그룹 가입 신청을 취소합니다.")
     @PostMapping("/sign/cancel")
-    public ResponseEntity<ResponseGroupMemberDto> cancelSignGroup(@LoginUser User user, @RequestBody RequestGroupMemberDto requestGroupMemberDto) {
-        groupMemberService.cancelSignGroup(user, requestGroupMemberDto.groupId());
+    public ResponseEntity<ResponseGroupMemberDto> cancelSignGroup(@LoginUser User user, @RequestBody CancelSignRequestDto cancelSignRequestDto) {
+        groupMemberService.cancelSignGroup(user, cancelSignRequestDto.groupId());
         return ResponseEntity.ok(ResponseGroupMemberDto.success(HttpStatus.OK, "가입신청을 취소했습니다."));
     }
 
     @Operation(summary = "그룹 가입 신청", description = "로그인한 유저가 그룹 가입 신청을 합니다.")
     @PostMapping("/sign")
-    public ResponseEntity<ResponseGroupMemberDto> signGroup(@LoginUser User user, @RequestBody RequestGroupMemberDto requestGroupMemberDto) {
-        GroupMember groupMember = GroupMemberFacade.signGroup(user, requestGroupMemberDto.groupId(), requestGroupMemberDto.intro());
+    public ResponseEntity<ResponseGroupMemberDto> signGroup(@LoginUser User user, @RequestBody SignGroupRequestDto signGroupRequestDto) {
+        GroupMember groupMember = GroupMemberFacade.signGroup(user, signGroupRequestDto.groupId(), signGroupRequestDto.intro());
 
         return ResponseEntity.ok(ResponseGroupMemberDto.success(HttpStatus.CREATED, "가입신청을 완료했습니다."));
     }
 
     @Operation(summary = "그룹장 위임", description = "특정 유저에게 그룹장 권한을 위임합니다.")
     @PutMapping("/change")
-    public ResponseEntity changeGroupLeader(@LoginUser User user, @RequestBody RequestGroupMemberDto requestGroupMemberDto) {
-        groupMemberService.changeLeader(requestGroupMemberDto.groupId(), user, requestGroupMemberDto.userId());
+    public ResponseEntity changeGroupLeader(@LoginUser User user, @RequestBody ChangeLeaderRequestDto changeLeaderRequestDto) {
+        groupMemberService.changeLeader(changeLeaderRequestDto.groupId(), user, changeLeaderRequestDto.userId());
 
         return ResponseEntity.ok(ResponseGroupMemberDto.success(HttpStatus.OK, "그룹장 위임이 완료되었습니다."));
     }
@@ -79,11 +77,11 @@ public class GroupMemberController {
             description = "그룹장이 모임에 가입 신청한 사용자 목록을 조회합니다."
     )
     @GetMapping("/{groupId}/join-requests")
-    public ResponseEntity<List<JoinRequestDto>> getAllJoinRequest(
+    public ResponseEntity<List<SignResponseDto>> getAllJoinRequest(
             @LoginUser User user, @PathVariable Long groupId
     ) {
         List<GroupMember> members = groupMemberService.findByGroupAndPendingUser(user, groupId);
 
-        return ResponseEntity.ok(JoinRequestDto.from(members));
+        return ResponseEntity.ok(SignResponseDto.from(members));
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/domain/GroupMember.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/domain/GroupMember.java
@@ -53,15 +53,18 @@ public class GroupMember extends BaseEntity {
 
     private LocalDateTime leftAt;
 
+    private String intro;
+
     @CreatedDate
     private LocalDateTime joinAt;
 
     @Builder
-    public GroupMember(Group group, User user, GroupRole role, GroupMemberStatus status) {
+    public GroupMember(Group group, User user, GroupRole role, GroupMemberStatus status,String intro) {
         this.group = group;
         this.user = user;
         this.role = role;
         this.status = status;
+        this.intro = intro;
     }
 
     protected GroupMember() {
@@ -97,11 +100,12 @@ public class GroupMember extends BaseEntity {
                 build();
     }
 
-    public static GroupMember sign(User signedUser, Group targetGroup) {
+    public static GroupMember sign(User signedUser, Group targetGroup, String intro) {
         return GroupMember.builder().
                 group(targetGroup).
                 user(signedUser).role(MEMBER).
                 status(PENDING).
+                intro(intro).
                 build();
     }
 
@@ -114,7 +118,7 @@ public class GroupMember extends BaseEntity {
         }
         if (this.status == GroupMemberStatus.BANNED) {
             throw new GroupMemberException(MEMBER_HAS_BANNED);
-        }else
+        } else
             this.status = ACTIVE;
     }
 
@@ -140,7 +144,7 @@ public class GroupMember extends BaseEntity {
 
 
     public void changeToLeader() {
-        if(this.role == LEADER){
+        if (this.role == LEADER) {
             throw new GroupException(WRONG_GROUP_ACCESS);
         }
         this.role = LEADER;
@@ -162,6 +166,7 @@ public class GroupMember extends BaseEntity {
             throw new GroupMemberException(MEMBER_CANNOT_CANCEL);
 
     }
+
     public void checkUserIsActive() {
         if (this.status != ACTIVE) {
             throw new GroupMemberException(GROUP_MEMBER_NOT_FOUND);

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/ApproveJoinRequestDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/ApproveJoinRequestDto.java
@@ -1,0 +1,4 @@
+package com.kakaotechcampus.team16be.groupMember.dto;
+
+public record ApproveJoinRequestDto(Long groupId, Long userId) {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/BanMemberRequestDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/BanMemberRequestDto.java
@@ -1,0 +1,4 @@
+package com.kakaotechcampus.team16be.groupMember.dto;
+
+public record BanMemberRequestDto(Long groupId, Long userId) {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/CancelSignRequestDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/CancelSignRequestDto.java
@@ -1,0 +1,4 @@
+package com.kakaotechcampus.team16be.groupMember.dto;
+
+public record CancelSignRequestDto(Long groupId) {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/ChangeLeaderRequestDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/ChangeLeaderRequestDto.java
@@ -1,0 +1,4 @@
+package com.kakaotechcampus.team16be.groupMember.dto;
+
+public record ChangeLeaderRequestDto(Long groupId, Long userId) {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/JoinRequestDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/JoinRequestDto.java
@@ -1,0 +1,19 @@
+package com.kakaotechcampus.team16be.groupMember.dto;
+
+import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
+
+import java.util.List;
+
+public record JoinRequestDto(
+        Long userId,
+        String intro
+) {
+    public static List<JoinRequestDto> from(List<GroupMember> members) {
+        return members.stream()
+                .map(m -> new JoinRequestDto(
+                        m.getUser().getId(),
+                        m.getIntro()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/LeaveGroupRequestDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/LeaveGroupRequestDto.java
@@ -1,0 +1,4 @@
+package com.kakaotechcampus.team16be.groupMember.dto;
+
+public record LeaveGroupRequestDto(Long groupId) {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/RequestGroupMemberDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/RequestGroupMemberDto.java
@@ -1,4 +1,8 @@
 package com.kakaotechcampus.team16be.groupMember.dto;
 
-public record RequestGroupMemberDto(Long groupId, Long userId) {
+public record RequestGroupMemberDto(
+        Long groupId,
+        Long userId,
+        String intro
+) {
 }

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/SignGroupRequestDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/SignGroupRequestDto.java
@@ -1,8 +1,8 @@
 package com.kakaotechcampus.team16be.groupMember.dto;
 
-public record RequestGroupMemberDto(
+public record SignGroupRequestDto(
         Long groupId,
         Long userId,
         String intro
-) {
+)  {
 }

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/SignResponseDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/SignResponseDto.java
@@ -4,13 +4,13 @@ import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
 
 import java.util.List;
 
-public record JoinRequestDto(
+public record SignResponseDto(
         Long userId,
         String intro
 ) {
-    public static List<JoinRequestDto> from(List<GroupMember> members) {
+    public static List<SignResponseDto> from(List<GroupMember> members) {
         return members.stream()
-                .map(m -> new JoinRequestDto(
+                .map(m -> new SignResponseDto(
                         m.getUser().getId(),
                         m.getIntro()
                 ))

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/repository/GroupMemberRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/repository/GroupMemberRepository.java
@@ -2,6 +2,7 @@ package com.kakaotechcampus.team16be.groupMember.repository;
 
 import com.kakaotechcampus.team16be.group.domain.Group;
 import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
+import com.kakaotechcampus.team16be.groupMember.domain.GroupMemberStatus;
 import com.kakaotechcampus.team16be.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -14,4 +15,6 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember,Long> {
     Optional<GroupMember> findByGroupAndUser(Group group, User user);
 
     List<GroupMember> findAllByGroup(Group group);
+
+    List<GroupMember> findAllByGroupAndStatus(Group group, GroupMemberStatus status);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberFacade.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberFacade.java
@@ -1,0 +1,98 @@
+package com.kakaotechcampus.team16be.groupMember.service;
+
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.group.service.GroupService;
+import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
+import com.kakaotechcampus.team16be.groupMember.exception.GroupMemberException;
+import com.kakaotechcampus.team16be.groupMember.repository.GroupMemberRepository;
+import com.kakaotechcampus.team16be.notification.service.NotificationService;
+import com.kakaotechcampus.team16be.user.domain.User;
+import com.kakaotechcampus.team16be.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class GroupMemberFacade {
+
+    private final NotificationService notificationService;
+    private final GroupMemberService groupMemberService;
+    private final GroupService groupService;
+    private final UserService userService;
+    private final GroupMemberRepository groupMemberRepository;
+
+
+    @Transactional
+    public GroupMember joinGroup(Long groupId, Long joinerId, Long leaderId) throws GroupMemberException {
+        Group group = groupService.findGroupById(groupId);
+
+        User leader = userService.findById(leaderId);
+        group.checkLeader(leader);
+
+        User joiner = userService.findById(joinerId);
+
+        Optional<GroupMember> existingMember = groupMemberRepository.findByGroupAndUser(group, joiner);
+
+        if (existingMember.isPresent()) {
+            GroupMember member = existingMember.get();
+            member.acceptJoin();
+            notificationService.createGroupJoinNotification(joiner, group);
+            return member;
+        } else {
+            GroupMember newMember = GroupMember.acceptJoin(group, joiner);
+            notificationService.createGroupJoinNotification(joiner, group);
+            return groupMemberRepository.save(newMember);
+        }
+    }
+
+
+    @Transactional
+    public GroupMember signGroup(User user, Long groupId,String intro) {
+        User signedUser = userService.findById(user.getId());
+        Group targetGroup = groupService.findGroupById(groupId);
+
+        GroupMember signMember = GroupMember.sign(signedUser, targetGroup, intro);
+        notificationService.createGroupSignNotification(targetGroup.getLeader(), targetGroup);
+
+        return groupMemberRepository.save(signMember);
+    }
+
+
+    @Transactional
+    public GroupMember leaveGroup(Long groupId, Long userId) {
+        Group group = groupService.findGroupById(groupId);
+
+        User user = userService.findById(userId);
+
+        GroupMember member = groupMemberService.findByGroupAndUser(group, user);
+
+        GroupMember.checkLeftGroup(member);
+
+
+        member.leaveGroup();
+        notificationService.createGroupLeaveNotification(user, group);
+        return member;
+    }
+
+    @Transactional
+    public GroupMember bannedGroup(Long groupId, Long userId, User leaderUser) {
+        Group group = groupService.findGroupById(groupId);
+
+        group.checkLeader(leaderUser);
+
+        User bannedUser = userService.findById(userId);
+
+        GroupMember member = groupMemberService.findByGroupAndUser(group, bannedUser);
+
+        member.bannedGroup();
+
+        notificationService.createGroupBannedNotification(bannedUser, group);
+
+        return member;
+
+    }
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberService.java
@@ -7,19 +7,12 @@ import com.kakaotechcampus.team16be.user.domain.User;
 import java.util.List;
 
 public interface GroupMemberService {
-    GroupMember joinGroup(Long groupId, Long joinerId,Long userId);
-
-    GroupMember leaveGroup(Long groupId, Long userId);
-
-    GroupMember bannedGroup(Long groupId, Long userId, User leader);
 
     GroupMember findByGroupAndUser(Group group, User user);
 
     boolean checkMemberHasLeft(Group targetGroup, User user);
 
     void createGroup(Group createdGroup, User user);
-
-    GroupMember signGroup(User user, Long groupId);
 
     void changeLeader(Long groupId, User oldLeader, Long newLeaderId);
 
@@ -29,4 +22,5 @@ public interface GroupMemberService {
 
     void validateGroupMember(User user, Long groupId);
 
+    List<GroupMember> findByGroupAndPendingUser(User user, Long groupId);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
@@ -132,6 +132,8 @@ public class GroupMemberServiceImpl implements GroupMemberService {
 
         member.bannedGroup();
 
+        notificationService.createGroupBannedNotification(bannedUser, group);
+
         return member;
 
     }

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
@@ -5,6 +5,7 @@ import com.kakaotechcampus.team16be.group.service.GroupService;
 import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
 import com.kakaotechcampus.team16be.groupMember.exception.GroupMemberException;
 import com.kakaotechcampus.team16be.groupMember.repository.GroupMemberRepository;
+import com.kakaotechcampus.team16be.notification.service.NotificationService;
 import com.kakaotechcampus.team16be.user.domain.User;
 import com.kakaotechcampus.team16be.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class GroupMemberServiceImpl implements GroupMemberService {
     private final GroupMemberRepository groupMemberRepository;
     private final GroupService groupService;
     private final UserService userService;
+    private final NotificationService notificationService;
 
 
     @Transactional
@@ -77,7 +79,8 @@ public class GroupMemberServiceImpl implements GroupMemberService {
         User signedUser = userService.findById(user.getId());
         Group targetGroup = groupService.findGroupById(groupId);
 
-         GroupMember signMember = GroupMember.sign(signedUser, targetGroup);
+        GroupMember signMember = GroupMember.sign(signedUser, targetGroup);
+        notificationService.createGroupJoinNotification(targetGroup.getLeader(), targetGroup);
 
         return groupMemberRepository.save(signMember);
     }

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.kakaotechcampus.team16be.groupMember.domain.GroupMemberStatus.*;
 import static com.kakaotechcampus.team16be.groupMember.exception.GroupMemberErrorCode.*;

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
@@ -43,6 +43,7 @@ public class GroupMemberServiceImpl implements GroupMemberService {
     if (existingMember.isPresent()) {
         GroupMember member = existingMember.get();
         member.acceptJoin();
+        notificationService.createGroupJoinNotification(joiner, group);
         return member;
     }
     else {
@@ -80,7 +81,7 @@ public class GroupMemberServiceImpl implements GroupMemberService {
         Group targetGroup = groupService.findGroupById(groupId);
 
         GroupMember signMember = GroupMember.sign(signedUser, targetGroup);
-        notificationService.createGroupJoinNotification(targetGroup.getLeader(), targetGroup);
+        notificationService.createGroupSignNotification(targetGroup.getLeader(), targetGroup);
 
         return groupMemberRepository.save(signMember);
     }
@@ -115,7 +116,7 @@ public class GroupMemberServiceImpl implements GroupMemberService {
 
 
         member.leaveGroup();
-
+        notificationService.createGroupLeaveNotification(user, group);
         return member;
     }
 

--- a/src/main/java/com/kakaotechcampus/team16be/notification/controller/NotificationController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/controller/NotificationController.java
@@ -32,6 +32,10 @@ public class NotificationController {
         return notificationService.connectNotification(user);
     }
 
+    @Operation(
+            summary = "전체 알림 조회",
+            description = "로그인한 사용자가 받은 모든 알림을 조회합니다."
+    )
     @GetMapping
     public ResponseEntity<List<ResponseNotification>> getAllNotifications(@LoginUser User user) {
         List<ResponseNotification> notifications = notificationService.getAllNotifications(user);

--- a/src/main/java/com/kakaotechcampus/team16be/notification/controller/NotificationController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/controller/NotificationController.java
@@ -1,15 +1,18 @@
 package com.kakaotechcampus.team16be.notification.controller;
 
 import com.kakaotechcampus.team16be.common.annotation.LoginUser;
+import com.kakaotechcampus.team16be.notification.dto.ResponseNotification;
 import com.kakaotechcampus.team16be.notification.service.NotificationService;
 import com.kakaotechcampus.team16be.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,6 +30,12 @@ public class NotificationController {
     @GetMapping("/subscribe")
     public SseEmitter subscribe(@LoginUser User user) {
         return notificationService.connectNotification(user);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ResponseNotification>> getAllNotifications(@LoginUser User user) {
+        List<ResponseNotification> notifications = notificationService.getAllNotifications(user);
+        return ResponseEntity.ok(notifications);
     }
 
 }

--- a/src/main/java/com/kakaotechcampus/team16be/notification/controller/NotificationController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/controller/NotificationController.java
@@ -3,6 +3,7 @@ package com.kakaotechcampus.team16be.notification.controller;
 import com.kakaotechcampus.team16be.common.annotation.LoginUser;
 import com.kakaotechcampus.team16be.notification.service.NotificationService;
 import com.kakaotechcampus.team16be.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,8 +19,14 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
+    @Operation(
+            summary = "알림 구독",
+            description = "사용자가 SSE(Server-Sent Events) 방식으로 실시간 알림을 구독합니다. " +
+                    "이 API를 호출하면 서버와의 연결이 유지되며, 새로운 알림이 발생할 때마다 클라이언트로 이벤트가 전송됩니다."
+    )
     @GetMapping("/subscribe")
     public SseEmitter subscribe(@LoginUser User user) {
         return notificationService.connectNotification(user);
     }
+
 }

--- a/src/main/java/com/kakaotechcampus/team16be/notification/controller/NotificationController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/controller/NotificationController.java
@@ -1,0 +1,25 @@
+package com.kakaotechcampus.team16be.notification.controller;
+
+import com.kakaotechcampus.team16be.common.annotation.LoginUser;
+import com.kakaotechcampus.team16be.notification.service.NotificationService;
+import com.kakaotechcampus.team16be.user.domain.User;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notification")
+@Tag(name = "알림 API", description = "알림 관련 API")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping("/subscribe")
+    public SseEmitter subscribe(@LoginUser User user) {
+        return notificationService.connectNotification(user);
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/notification/domain/Notification.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/domain/Notification.java
@@ -1,0 +1,59 @@
+package com.kakaotechcampus.team16be.notification.domain;
+
+import com.kakaotechcampus.team16be.common.BaseEntity;
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User receiver;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name ="related_group_id",nullable = false)
+    private Group relatedGroup;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "related_user_id", nullable = false)
+    private User relatedUser;
+
+    private String message;
+
+    private Boolean isRead = false;
+
+    @Builder
+    public Notification(User receiver, NotificationType notificationType, Group relatedGroup, User relatedUser, String message) {
+        this.receiver = receiver;
+        this.notificationType = notificationType;
+        this.relatedGroup = relatedGroup;
+        this.relatedUser = relatedUser;
+        this.message = message;
+    }
+
+    public static Notification createNotification(User receiver, Notification notificationType, Group relatedGroup, User relatedUser) {
+        return Notification.builder()
+                .receiver(receiver)
+                .notificationType(notificationType.notificationType)
+                .relatedGroup(relatedGroup)
+                .relatedUser(relatedUser)
+                .message(notificationType.getMessage())
+                .build();
+    }
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/notification/domain/NotificationType.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/domain/NotificationType.java
@@ -2,5 +2,6 @@ package com.kakaotechcampus.team16be.notification.domain;
 
 public enum NotificationType {
     GROUP_JOIN_REQUEST,
-    GROUP_JOIN_LEFT
+    GROUP_JOIN_LEFT,
+    CHANGE_GROUP_PLAN
 }

--- a/src/main/java/com/kakaotechcampus/team16be/notification/domain/NotificationType.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/domain/NotificationType.java
@@ -3,5 +3,6 @@ package com.kakaotechcampus.team16be.notification.domain;
 public enum NotificationType {
     GROUP_JOIN_REQUEST,
     GROUP_JOIN_LEFT,
-    CHANGE_GROUP_PLAN
+    CHANGE_GROUP_PLAN,
+    GROUP_JOIN_BANNED
 }

--- a/src/main/java/com/kakaotechcampus/team16be/notification/domain/NotificationType.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/domain/NotificationType.java
@@ -1,0 +1,6 @@
+package com.kakaotechcampus.team16be.notification.domain;
+
+public enum NotificationType {
+    GROUP_JOIN_REQUEST,
+    GROUP_JOIN_LEFT
+}

--- a/src/main/java/com/kakaotechcampus/team16be/notification/dto/ResponseNotification.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/dto/ResponseNotification.java
@@ -1,0 +1,27 @@
+package com.kakaotechcampus.team16be.notification.dto;
+
+import com.kakaotechcampus.team16be.notification.domain.Notification;
+import com.kakaotechcampus.team16be.notification.domain.NotificationType;
+
+public record ResponseNotification(
+        Long alarmId,
+        Long receiverId,
+        NotificationType notificationType,
+        Long relatedGroupId,
+        Long relatedUserId,
+        String message,
+        Boolean isRead
+
+) {
+
+    public static ResponseNotification from(Notification notification
+    ) {
+        return new ResponseNotification(notification.getId(),
+                notification.getReceiver().getId(),
+                notification.getNotificationType(),
+                notification.getRelatedGroup().getId(),
+                notification.getRelatedUser().getId(),
+                notification.getMessage(),
+                notification.getIsRead());
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/notification/exception/NotificationErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/exception/NotificationErrorCode.java
@@ -1,0 +1,17 @@
+package com.kakaotechcampus.team16be.notification.exception;
+
+import com.kakaotechcampus.team16be.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorCode implements ErrorCode {
+
+    NOTIFICATION_CONNECTION_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "NOTIFICATION-001", "알림 SSE 연결 중 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/kakaotechcampus/team16be/notification/exception/NotificationException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/exception/NotificationException.java
@@ -1,0 +1,27 @@
+package com.kakaotechcampus.team16be.notification.exception;
+
+import com.kakaotechcampus.team16be.common.exception.BaseException;
+
+public class NotificationException extends BaseException {
+
+    private final NotificationErrorCode errorCode;
+
+    public NotificationException(NotificationErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+
+    @Override
+    public String getCode() {
+        return errorCode.getCode();
+    }
+
+    @Override
+    public int getStatus() {
+        return errorCode.getStatus().value();
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/repository/EmitterRepository.java
@@ -1,0 +1,36 @@
+package com.kakaotechcampus.team16be.notification.repository;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Repository
+public class EmitterRepository {
+
+    private Map<String, SseEmitter> emitterMap = new ConcurrentHashMap<>();
+
+    public SseEmitter save(Long userId, SseEmitter sseEmitter) {
+        emitterMap.put(getKey(userId), sseEmitter);
+        log.info("Saved SseEmitter for {}", userId);
+        return sseEmitter;
+    }
+
+    public Optional<SseEmitter> get(Long userId) {
+        log.info("Got SseEmitter for {}", userId);
+        return Optional.ofNullable(emitterMap.get(getKey(userId)));
+    }
+
+    public void delete(Long userId) {
+        emitterMap.remove(getKey(userId));
+        log.info("Deleted SseEmitter for {}", userId);
+    }
+
+    private String getKey(Long userId) {
+        return "Emitter:UID:" + userId;
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/repository/NotificationRepository.java
@@ -1,7 +1,12 @@
 package com.kakaotechcampus.team16be.notification.repository;
 
 import com.kakaotechcampus.team16be.notification.domain.Notification;
+import com.kakaotechcampus.team16be.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findAllByReceiverOrderByCreatedAtDesc(User receiver);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.kakaotechcampus.team16be.notification.repository;
+
+import com.kakaotechcampus.team16be.notification.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationService.java
@@ -8,6 +8,9 @@ public interface NotificationService {
 
     SseEmitter connectNotification(User user);
 
-    void createGroupJoinNotification(User targetUser, Group targetGroup);
+    void createGroupSignNotification(User targetUser, Group targetGroup);
 
+    void createGroupJoinNotification(User joiner, Group targetGroup);
+
+    void createGroupLeaveNotification(User user, Group group);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationService.java
@@ -1,0 +1,13 @@
+package com.kakaotechcampus.team16be.notification.service;
+
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.user.domain.User;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface NotificationService {
+
+    SseEmitter connectNotification(User user);
+
+    void createGroupJoinNotification(User targetUser, Group targetGroup);
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationService.java
@@ -19,4 +19,6 @@ public interface NotificationService {
     void createGroupLeaveNotification(User user, Group group);
 
     void createPlanUpdateNotifications(Plan plan, List<GroupMember> members);
+
+    void createGroupBannedNotification(User bannedUser, Group group);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationService.java
@@ -2,6 +2,7 @@ package com.kakaotechcampus.team16be.notification.service;
 
 import com.kakaotechcampus.team16be.group.domain.Group;
 import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
+import com.kakaotechcampus.team16be.notification.dto.ResponseNotification;
 import com.kakaotechcampus.team16be.plan.domain.Plan;
 import com.kakaotechcampus.team16be.user.domain.User;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -21,4 +22,6 @@ public interface NotificationService {
     void createPlanUpdateNotifications(Plan plan, List<GroupMember> members);
 
     void createGroupBannedNotification(User bannedUser, Group group);
+
+    List<ResponseNotification> getAllNotifications(User user);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationService.java
@@ -1,8 +1,12 @@
 package com.kakaotechcampus.team16be.notification.service;
 
 import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
+import com.kakaotechcampus.team16be.plan.domain.Plan;
 import com.kakaotechcampus.team16be.user.domain.User;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
 
 public interface NotificationService {
 
@@ -13,4 +17,6 @@ public interface NotificationService {
     void createGroupJoinNotification(User joiner, Group targetGroup);
 
     void createGroupLeaveNotification(User user, Group group);
+
+    void createPlanUpdateNotifications(Plan plan, List<GroupMember> members);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,76 @@
+package com.kakaotechcampus.team16be.notification.service;
+
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.notification.domain.Notification;
+import com.kakaotechcampus.team16be.notification.exception.NotificationErrorCode;
+import com.kakaotechcampus.team16be.notification.exception.NotificationException;
+import com.kakaotechcampus.team16be.notification.repository.EmitterRepository;
+import com.kakaotechcampus.team16be.notification.repository.NotificationRepository;
+import com.kakaotechcampus.team16be.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import java.io.IOException;
+
+import static com.kakaotechcampus.team16be.notification.domain.NotificationType.GROUP_JOIN_REQUEST;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+    private final static Long DEFAULT_TIMEOUT = 3600000L;
+    private final static String NOTIFICATION_NAME = "notify";
+
+    private final EmitterRepository emitterRepository;
+    private final NotificationRepository notificationRepository;
+
+    public SseEmitter connectNotification(User user) {
+
+        SseEmitter sseEmitter = new SseEmitter(DEFAULT_TIMEOUT);
+
+        emitterRepository.save(user.getId(), sseEmitter);
+
+        sseEmitter.onCompletion(() -> emitterRepository.delete(user.getId()));
+        sseEmitter.onTimeout(() -> emitterRepository.delete(user.getId()));
+
+        try {
+            sseEmitter.send(SseEmitter.event()
+                    .id("")
+                    .name(NOTIFICATION_NAME)
+                    .data("Connection completed"));
+        } catch (IOException exception) {
+            throw new NotificationException(NotificationErrorCode.NOTIFICATION_CONNECTION_ERROR);
+        }
+        return sseEmitter;
+    }
+
+    public void send(User user, Long notificationId) {
+        emitterRepository.get(user.getId()).ifPresentOrElse(sseEmitter -> {
+            try {
+                sseEmitter.send(SseEmitter.event()
+                        .id(notificationId.toString())
+                        .name(NOTIFICATION_NAME)
+                        .data("새로운 알림이 도착했습니다."));
+            } catch (IOException exception) {
+                emitterRepository.delete(user.getId());
+                throw new NotificationException(NotificationErrorCode.NOTIFICATION_CONNECTION_ERROR);
+            }
+        }, () -> log.info("No emitter found"));
+    }
+
+    public void createGroupJoinNotification(User targetUser, Group targetGroup) {
+        Notification notification = Notification.builder()
+                .notificationType(GROUP_JOIN_REQUEST)
+                .receiver(targetGroup.getLeader())
+                .relatedGroup(targetGroup)
+                .relatedUser(targetUser)
+                .message("[" + targetGroup.getName() + "] 그룹에 " + targetUser.getNickname() + "님이 가입을 요청했습니다.")
+                .build();
+
+        notificationRepository.save(notification);
+
+        send(targetGroup.getLeader(), notification.getId());
+    }
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationServiceImpl.java
@@ -10,9 +10,11 @@ import com.kakaotechcampus.team16be.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.io.IOException;
 
+import static com.kakaotechcampus.team16be.notification.domain.NotificationType.GROUP_JOIN_LEFT;
 import static com.kakaotechcampus.team16be.notification.domain.NotificationType.GROUP_JOIN_REQUEST;
 
 @Slf4j
@@ -59,13 +61,14 @@ public class NotificationServiceImpl implements NotificationService {
         }, () -> log.info("No emitter found"));
     }
 
+    @Transactional
     public void createGroupSignNotification(User targetUser, Group targetGroup) {
         Notification notification = Notification.builder()
                 .notificationType(GROUP_JOIN_REQUEST)
                 .receiver(targetGroup.getLeader())
                 .relatedGroup(targetGroup)
                 .relatedUser(targetUser)
-                .message("[" + targetGroup.getName() + "] 그룹에 " + targetUser.getNickname() + "님이 가입을 요청했습니다.")
+                .message("[" + targetGroup.getName() + "] 모임에 " + targetUser.getNickname() + "님이 가입을 요청했습니다.")
                 .build();
 
         notificationRepository.save(notification);
@@ -73,13 +76,14 @@ public class NotificationServiceImpl implements NotificationService {
         send(targetGroup.getLeader(), notification.getId(),notification.getMessage());
     }
 
+    @Transactional
     public void createGroupJoinNotification(User joiner, Group targetGroup) {
         Notification notification = Notification.builder()
                 .notificationType(GROUP_JOIN_REQUEST)
                 .receiver(joiner)
                 .relatedGroup(targetGroup)
                 .relatedUser(targetGroup.getLeader())
-                .message("[" + targetGroup.getName() + "] 그룹에 가입되었습니다.")
+                .message("[" + targetGroup.getName() + "] 모임에 가입되었습니다.")
                 .build();
 
         notificationRepository.save(notification);
@@ -87,5 +91,18 @@ public class NotificationServiceImpl implements NotificationService {
         send(joiner, notification.getId(),notification.getMessage());
     }
 
+    @Transactional
+    public void createGroupLeaveNotification(User leftUser, Group group) {
+        Notification notification = Notification.builder()
+                .notificationType(GROUP_JOIN_LEFT)
+                .receiver(group.getLeader())
+                .relatedGroup(group)
+                .relatedUser(leftUser)
+                .message("[" + group.getName() + "]모임에서 "+leftUser.getNickname()+"님이 탈퇴했습니다..")
+                .build();
 
+        notificationRepository.save(notification);
+
+        send(group.getLeader(), notification.getId(),notification.getMessage());
+    }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationServiceImpl.java
@@ -59,7 +59,7 @@ public class NotificationServiceImpl implements NotificationService {
         }, () -> log.info("No emitter found"));
     }
 
-    public void createGroupJoinNotification(User targetUser, Group targetGroup) {
+    public void createGroupSignNotification(User targetUser, Group targetGroup) {
         Notification notification = Notification.builder()
                 .notificationType(GROUP_JOIN_REQUEST)
                 .receiver(targetGroup.getLeader())
@@ -72,5 +72,20 @@ public class NotificationServiceImpl implements NotificationService {
 
         send(targetGroup.getLeader(), notification.getId(),notification.getMessage());
     }
+
+    public void createGroupJoinNotification(User joiner, Group targetGroup) {
+        Notification notification = Notification.builder()
+                .notificationType(GROUP_JOIN_REQUEST)
+                .receiver(joiner)
+                .relatedGroup(targetGroup)
+                .relatedUser(targetGroup.getLeader())
+                .message("[" + targetGroup.getName() + "] 그룹에 가입되었습니다.")
+                .build();
+
+        notificationRepository.save(notification);
+
+        send(joiner, notification.getId(),notification.getMessage());
+    }
+
 
 }

--- a/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationServiceImpl.java
@@ -45,13 +45,13 @@ public class NotificationServiceImpl implements NotificationService {
         return sseEmitter;
     }
 
-    public void send(User user, Long notificationId) {
+    public void send(User user, Long notificationId,String message) {
         emitterRepository.get(user.getId()).ifPresentOrElse(sseEmitter -> {
             try {
                 sseEmitter.send(SseEmitter.event()
                         .id(notificationId.toString())
                         .name(NOTIFICATION_NAME)
-                        .data("새로운 알림이 도착했습니다."));
+                        .data(message));
             } catch (IOException exception) {
                 emitterRepository.delete(user.getId());
                 throw new NotificationException(NotificationErrorCode.NOTIFICATION_CONNECTION_ERROR);
@@ -70,7 +70,7 @@ public class NotificationServiceImpl implements NotificationService {
 
         notificationRepository.save(notification);
 
-        send(targetGroup.getLeader(), notification.getId());
+        send(targetGroup.getLeader(), notification.getId(),notification.getMessage());
     }
 
 }

--- a/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationServiceImpl.java
@@ -3,6 +3,7 @@ package com.kakaotechcampus.team16be.notification.service;
 import com.kakaotechcampus.team16be.group.domain.Group;
 import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
 import com.kakaotechcampus.team16be.notification.domain.Notification;
+import com.kakaotechcampus.team16be.notification.dto.ResponseNotification;
 import com.kakaotechcampus.team16be.notification.exception.NotificationErrorCode;
 import com.kakaotechcampus.team16be.notification.exception.NotificationException;
 import com.kakaotechcampus.team16be.notification.repository.EmitterRepository;
@@ -142,5 +143,14 @@ public class NotificationServiceImpl implements NotificationService {
         notificationRepository.save(notification);
 
         send(bannedUser, notification.getId(),notification.getMessage());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ResponseNotification> getAllNotifications(User user) {
+        List<Notification> notifications = notificationRepository.findAllByReceiverOrderByCreatedAtDesc((user));
+        return notifications.stream()
+                .map(ResponseNotification::from)
+                .toList();
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationServiceImpl.java
@@ -112,6 +112,7 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Override
+    @Transactional
     public void createPlanUpdateNotifications(Plan plan, List<GroupMember> members) {
         for (GroupMember member : members) {
             Notification notification = Notification.builder()
@@ -125,5 +126,21 @@ public class NotificationServiceImpl implements NotificationService {
             notificationRepository.save(notification);
             send(member.getUser(), notification.getId(),notification.getMessage());
         }
+    }
+
+    @Override
+    @Transactional
+    public void createGroupBannedNotification(User bannedUser, Group group) {
+        Notification notification = Notification.builder()
+                .notificationType(GROUP_JOIN_BANNED)
+                .receiver(bannedUser)
+                .relatedGroup(group)
+                .relatedUser(group.getLeader())
+                .message("[" + group.getName() + "] 모임에서 강퇴되었습니다.")
+                .build();
+
+        notificationRepository.save(notification);
+
+        send(bannedUser, notification.getId(),notification.getMessage());
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/plan/domain/Plan.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/domain/Plan.java
@@ -47,83 +47,83 @@ public class Plan extends BaseEntity {
     @Column(name = "capacity", nullable = false)
     private Integer capacity;
 
-  @Column(name = "start_time", nullable = false)
-  private LocalDateTime startTime;
+    @Column(name = "start_time", nullable = false)
+    private LocalDateTime startTime;
 
     @Column(name = "end_time", nullable = false)
     private LocalDateTime endTime;
 
-  @Builder
-  public Plan(Group group, String title, String description, Integer capacity, LocalDateTime startTime, LocalDateTime endTime, Location location){
-    validateCapacity(capacity);
-    validateTimeRange(startTime, endTime);
+    @Builder
+    public Plan(Group group, String title, String description, Integer capacity, LocalDateTime startTime, LocalDateTime endTime, Location location) {
+        validateCapacity(capacity);
+        validateTimeRange(startTime, endTime);
 
-    this.group = group;
-    this.title = title;
-    this.description = description;
-    this.capacity = capacity;
-    this.startTime = startTime;
-    this.endTime = endTime;
-    this.location = location;
-  }
-
-  public void changePlan(PlanRequestDto dto) {
-    LocalDateTime newStartTime = dto.startTime() != null ? dto.startTime() : this.startTime;
-    LocalDateTime newEndTime = dto.endTime() != null ? dto.endTime() : this.endTime;
-    validateTimeRange(newStartTime, newEndTime);
-
-    if(dto.title() != null) {
-      this.title = dto.title();
+        this.group = group;
+        this.title = title;
+        this.description = description;
+        this.capacity = capacity;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.location = location;
     }
 
-    if(dto.description() != null) {
-      this.description = dto.description();
+    public void changePlan(PlanRequestDto dto) {
+        LocalDateTime newStartTime = dto.startTime() != null ? dto.startTime() : this.startTime;
+        LocalDateTime newEndTime = dto.endTime() != null ? dto.endTime() : this.endTime;
+        validateTimeRange(newStartTime, newEndTime);
+
+        if (dto.title() != null) {
+            this.title = dto.title();
+        }
+
+        if (dto.description() != null) {
+            this.description = dto.description();
+        }
+
+        if (dto.capacity() != null) {
+            validateCapacity(dto.capacity());
+            this.capacity = dto.capacity();
+        }
+
+        this.startTime = newStartTime;
+        this.endTime = newEndTime;
+
+        if (dto.location() != null) {
+            this.location = Location.builder()
+                    .name(dto.location().name())
+                    .latitude(dto.location().latitude())
+                    .longitude(dto.location().longitude())
+                    .build();
+        }
     }
 
-    if(dto.capacity() != null) {
-      validateCapacity(dto.capacity());
-      this.capacity = dto.capacity();
+    public static Plan create(Group group, String title, String description,
+                              Integer capacity, LocalDateTime startTime, LocalDateTime endTime, Location location
+    ) {
+        return Plan.builder()
+                .group(group)
+                .title(title)
+                .description(description)
+                .capacity(capacity)
+                .startTime(startTime)
+                .endTime(endTime)
+                .location(location)
+                .build();
     }
 
-    this.startTime = newStartTime;
-    this.endTime = newEndTime;
-
-    if (dto.location() != null) {
-      this.location = Location.builder()
-                              .name(dto.location().name())
-                              .latitude(dto.location().latitude())
-                              .longitude(dto.location().longitude())
-                              .build();
-    }
-  }
-
-  public static Plan create(Group group, String title, String description,
-      Integer capacity, LocalDateTime startTime, LocalDateTime endTime, Location location
-      ) {
-    return Plan.builder()
-               .group(group)
-               .title(title)
-               .description(description)
-               .capacity(capacity)
-               .startTime(startTime)
-               .endTime(endTime)
-               .location(location)
-               .build();
-  }
-
-  private void validateCapacity(Integer capacity) {
-    if(capacity == null || capacity <= 0) {
-      throw new PlanException(PlanErrorCode.INVALID_CAPACITY);
-    }
-  }
-
-  private void validateTimeRange(LocalDateTime startTime, LocalDateTime endTime) {
-    if (startTime == null || endTime == null) {
-      throw new PlanException(PlanErrorCode.TIME_REQUIRED);
+    private void validateCapacity(Integer capacity) {
+        if (capacity == null || capacity <= 0) {
+            throw new PlanException(PlanErrorCode.INVALID_CAPACITY);
+        }
     }
 
-    if (!startTime.isBefore(endTime)) {
-      throw new PlanException(PlanErrorCode.INVALID_TIME_RANGE);
+    private void validateTimeRange(LocalDateTime startTime, LocalDateTime endTime) {
+        if (startTime == null || endTime == null) {
+            throw new PlanException(PlanErrorCode.TIME_REQUIRED);
+        }
+
+        if (!startTime.isBefore(endTime)) {
+            throw new PlanException(PlanErrorCode.INVALID_TIME_RANGE);
+        }
     }
-  }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanServiceImpl.java
@@ -2,6 +2,10 @@ package com.kakaotechcampus.team16be.plan.service;
 
 import com.kakaotechcampus.team16be.group.domain.Group;
 import com.kakaotechcampus.team16be.group.service.GroupService;
+import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
+import com.kakaotechcampus.team16be.groupMember.service.GroupMemberService;
+import com.kakaotechcampus.team16be.notification.repository.NotificationRepository;
+import com.kakaotechcampus.team16be.notification.service.NotificationService;
 import com.kakaotechcampus.team16be.plan.domain.Location;
 import com.kakaotechcampus.team16be.plan.PlanRepository;
 import com.kakaotechcampus.team16be.plan.domain.Plan;
@@ -20,8 +24,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PlanServiceImpl implements PlanService {
 
-  private final PlanRepository planRepository;
-  private final GroupService groupService;
+
+    private final PlanRepository planRepository;
+    private final GroupService groupService;
+    private final NotificationService notificationService;
+    private final GroupMemberService groupMemberService;
 
   @Override
   @Transactional
@@ -75,6 +82,9 @@ public class PlanServiceImpl implements PlanService {
                               .orElseThrow(() -> new PlanException(PlanErrorCode.PLAN_NOT_FOUND));
 
     plan.changePlan(planRequestDto);
+      List<GroupMember> members = groupMemberService.findByGroup(plan.getGroup());
+
+    notificationService.createPlanUpdateNotifications(plan,members);
     return PlanResponseDto.from(plan);
   }
 


### PR DESCRIPTION
## 관련이슈
- close #120 

## 내용
### 1. Notification 엔티티 생성 및 NotificationRepository 생성

### 2. EmitterRepository 생성 (유저별 SSE 관리)

### 3. connectNotification(User user): 클라이언트 SSE 구독

### 4. send(User user, Long notificationId): 실시간적으로 특정 유저에게 알림을 전송하는 공통 로직
- 1. EmitterRepository에서 해당 유저의 SseEmitter를 가져옴
- 2. SseEmitter.send()를 통해 클라이언트로 이벤트 전송
- 3. 전송 실패 시 해당 SseEmitter 삭제 후 예외 처리
- 4. 결과: 클라이언트에서는 SSE 구독 중인 이벤트를 받아 "새로운 알림이 도착했습니다." 같은 데이터를 실시간으로 표시

### 5. 알림 종류 정의
- GROUP_JOIN_REQUEST → 가입 신청
- GROUP_MEMBER_WITHDRAWAL → 모임 유저가 그룹에서 탈퇴

### 6. 가입 요청/탈퇴 이벤트 연결
- 가입 신청 → createGroupJoinRequestNotification → 그룹장에게 알림
- 가입 승인 완료 → createGroupJoinNotification → 신청한 유저에게 알림
- 탈퇴 → createGroupMemberWithdrawalNotification → 그룹장에게 알림
- 강퇴 → createGroupMemberBannedNotification → 강퇴당한 유저에게 알림
- 가입 신청 취소 → createGroupJoinRequestCancelNotification → 그룹장에게 알림

### 7. 알림 조회
- 그룹장용 – 가입신청 알림 조회 -> 목적: 아직 처리 안 한 가입 요청 리스트 보여주기
- 일반 유저용 – 전체 알림 조회 -> 목적: 가입 승인, 댓글, 메시지 등 모든 알림 확인