### PR TITLE
fix: 게시글 조회 응답 데이터 확장 (댓글 수/좋아요 수/좋아요 여부)

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/post/controller/PostController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/post/controller/PostController.java
@@ -34,15 +34,15 @@ public class PostController {
 
     @Operation(summary = "게시글 조회", description = "특정 게시글을 조회합니다.")
     @GetMapping("/{groupId}/posts/{postId}")
-    public ResponseEntity<GetPostResponse> getPost(@PathVariable Long groupId, @PathVariable Long postId) {
-        GetPostResponse PostResponse = postService.getPost(groupId, postId);
+    public ResponseEntity<GetPostResponse> getPost(@LoginUser User user,@PathVariable Long groupId, @PathVariable Long postId) {
+        GetPostResponse PostResponse = postService.getPost(user,groupId, postId);
         return ResponseEntity.ok(PostResponse);
     }
 
     @Operation(summary = "게시글 전체 조회", description = "특정 그룹의 모든 게시글을 조회합니다.")
     @GetMapping("/{groupId}/posts")
-    public ResponseEntity<List<GetPostResponse>> getAllPosts(@PathVariable Long groupId) {
-        List<GetPostResponse> PostResponses = postService.getAllPosts(groupId);
+    public ResponseEntity<List<GetPostResponse>> getAllPosts(@LoginUser User user, @PathVariable Long groupId) {
+        List<GetPostResponse> PostResponses = postService.getAllPosts(user, groupId);
         return ResponseEntity.ok(PostResponses);
     }
 

--- a/src/main/java/com/kakaotechcampus/team16be/post/dto/GetPostResponse.java
+++ b/src/main/java/com/kakaotechcampus/team16be/post/dto/GetPostResponse.java
@@ -2,6 +2,7 @@ package com.kakaotechcampus.team16be.post.dto;
 
 import com.kakaotechcampus.team16be.post.domain.Post;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record GetPostResponse(
@@ -9,18 +10,23 @@ public record GetPostResponse(
         String authorNickname,
         String title,
         String content,
-        List<String> imageUrls
-//        String likeCount,
-//        String commentCount,
-//        boolean isLikedByCurrentUser
+        List<String> imageUrls,
+        Long likeCount,
+        Integer commentCount,
+        LocalDateTime createdAt,
+        boolean isLike
 ) {
-    public static GetPostResponse from(Post post, List<String> fullURLs) {
+    public static GetPostResponse from(Post post, List<String> fullURLs, Integer commentCount, boolean isLike) {
         return new GetPostResponse(
                 post.getId(),
                 post.getAuthor(),
                 post.getTitle(),
                 post.getContent(),
-                fullURLs
+                fullURLs,
+                post.getLikeCount(),
+                commentCount,
+                post.getCreatedAt(),
+                isLike
         );
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/post/service/PostService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/post/service/PostService.java
@@ -1,5 +1,6 @@
 package com.kakaotechcampus.team16be.post.service;
 
+import com.kakaotechcampus.team16be.common.annotation.LoginUser;
 import com.kakaotechcampus.team16be.post.domain.Post;
 import com.kakaotechcampus.team16be.post.dto.CreatePostRequest;
 import com.kakaotechcampus.team16be.post.dto.GetPostResponse;
@@ -14,9 +15,9 @@ import java.util.List;
 public interface PostService {
     Post createPost(User user, CreatePostRequest createPostRequest);
 
-    GetPostResponse getPost(Long groupId, Long postId);
+    GetPostResponse getPost(User user, Long groupId, Long postId);
 
-    List<GetPostResponse> getAllPosts(Long groupId);
+    List<GetPostResponse> getAllPosts(User user, Long groupId);
 
     void deletePost(User user, Long postId);
 

--- a/src/main/java/com/kakaotechcampus/team16be/post/service/PostServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/post/service/PostServiceImpl.java
@@ -1,10 +1,13 @@
 package com.kakaotechcampus.team16be.post.service;
 
 import com.kakaotechcampus.team16be.aws.service.S3UploadPresignedUrlService;
+import com.kakaotechcampus.team16be.comment.service.CommentService;
 import com.kakaotechcampus.team16be.group.domain.Group;
 import com.kakaotechcampus.team16be.group.service.GroupService;
 import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
 import com.kakaotechcampus.team16be.groupMember.service.GroupMemberService;
+import com.kakaotechcampus.team16be.like.dto.PostLikeResponse;
+import com.kakaotechcampus.team16be.like.service.PostLikeService;
 import com.kakaotechcampus.team16be.post.domain.Post;
 import com.kakaotechcampus.team16be.post.dto.CreatePostRequest;
 import com.kakaotechcampus.team16be.post.dto.GetPostResponse;
@@ -27,6 +30,8 @@ public class PostServiceImpl implements PostService {
     private final GroupService groupService;
     private final GroupMemberService groupMemberService;
     private final S3UploadPresignedUrlService s3UploadPresignedUrlService;
+    private final CommentService commentService;
+    private final PostLikeService postLikeService;
 
     @Override
     @Transactional
@@ -48,30 +53,35 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional(readOnly = true)
-    public GetPostResponse getPost(Long groupId, Long postId) {
+    public GetPostResponse getPost(User user, Long groupId, Long postId) {
         Group targetGroup = groupService.findGroupById(groupId);
         Post post = postRepository.findByIdAndGroup(postId, targetGroup)
                 .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+
+        Integer commentCount = commentService.getCommentsByPostId(postId).size();
+        PostLikeResponse postLikeResponse = postLikeService.getPostLikeInfo(user, postId);
 
         List<String> fullURLs = post.getImageUrls().stream()
                 .map(s3UploadPresignedUrlService::getPublicUrl)
                 .toList();
 
-        return GetPostResponse.from(post, fullURLs);
+        return GetPostResponse.from(post, fullURLs, commentCount, postLikeResponse.isLiked());
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<GetPostResponse> getAllPosts(Long groupId) {
+    public List<GetPostResponse> getAllPosts(User user, Long groupId) {
         Group targetGroup = groupService.findGroupById(groupId);
-        List<Post> posts = postRepository.findByGroup((targetGroup));
+        List<Post> posts = postRepository.findByGroup(targetGroup);
 
         return posts.stream()
                 .map(post -> {
                     List<String> fullURLs = post.getImageUrls().stream()
                             .map(s3UploadPresignedUrlService::getPublicUrl)
                             .toList();
-                    return GetPostResponse.from(post, fullURLs);
+                    Integer commentCount = commentService.getCommentsByPostId(post.getId()).size();
+                    PostLikeResponse postLikeResponse = postLikeService.getPostLikeInfo(user, post.getId());
+                    return GetPostResponse.from(post, fullURLs, commentCount,postLikeResponse.isLiked());
                 })
                 .toList();
     }


### PR DESCRIPTION
## 요청사항
게시글 조회 API 응답에 다음 정보가 추가되면 좋겠습니다:
- 댓글 개수
- 좋아요 수
- 현재 사용자가 해당 게시글에 좋아요를 눌렀는지 여부

## 필요성
- 프론트엔드에서 별도의 API 호출 없이 한 번에 필요한 데이터를 받을 수 있습니다.
- 사용자 경험(UX) 개선 및 API 호출 횟수 감소로 성능 최적화에 도움이 됩니다.

## 작업 내용
- 게시글 조회 시 댓글 개수, 좋아요 수, 좋아요 여부를 함께 반환하도록 응답 DTO 및 관련 컨트롤러 & 서비스 로직 수정