### PR TITLE
bugfix: 순환 참조 해결 및 Post/Comment 서비스 구조 개선

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/comment/controller/CommentController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/controller/CommentController.java
@@ -5,6 +5,7 @@ import com.kakaotechcampus.team16be.comment.dto.CommentIdResponse;
 import com.kakaotechcampus.team16be.comment.dto.CommentRequest;
 import com.kakaotechcampus.team16be.comment.dto.CommentResponse;
 import com.kakaotechcampus.team16be.comment.dto.CommentUpdateRequest;
+import com.kakaotechcampus.team16be.comment.service.CommentFacadeService;
 import com.kakaotechcampus.team16be.comment.service.CommentService;
 import com.kakaotechcampus.team16be.common.annotation.LoginUser;
 import com.kakaotechcampus.team16be.user.domain.User;
@@ -22,6 +23,7 @@ import java.util.List;
 public class CommentController {
 
     private final CommentService commentService;
+    private final CommentFacadeService commentFacadeService;
 
     @Operation(summary = "부모 댓글 작성", description = "부모 댓글을 작성합니다.(대댓글 X)")
     @PostMapping("/comments")
@@ -29,7 +31,7 @@ public class CommentController {
             @LoginUser User user,
             @RequestBody CommentRequest commentRequest
     ) {
-        Long commentId= commentService.createParentComment(user, commentRequest);
+        Long commentId= commentFacadeService.createParentComment(user, commentRequest);
         return ResponseEntity.ok(CommentIdResponse.from(commentId));
     }
 
@@ -39,7 +41,7 @@ public class CommentController {
             @LoginUser User user,
             @RequestBody CommentRequest commentRequest
     ) {
-        Long commentId = commentService.createChildComment(user, commentRequest);
+        Long commentId = commentFacadeService.createChildComment(user, commentRequest);
         return ResponseEntity.ok(CommentIdResponse.from(commentId));
     }
 
@@ -48,7 +50,7 @@ public class CommentController {
     public ResponseEntity<List<CommentResponse>> getAllComments(
             @PathVariable Long postId
     ) {
-        List<Comment> comments = commentService.getCommentsByPostId(postId);
+        List<Comment> comments = commentFacadeService.getCommentsByPostId(postId);
         return ResponseEntity.ok(CommentResponse.from(comments));
     }
 

--- a/src/main/java/com/kakaotechcampus/team16be/comment/service/CommentFacadeService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/service/CommentFacadeService.java
@@ -1,0 +1,50 @@
+package com.kakaotechcampus.team16be.comment.service;
+
+import com.kakaotechcampus.team16be.comment.domain.Comment;
+import com.kakaotechcampus.team16be.comment.dto.CommentRequest;
+import com.kakaotechcampus.team16be.comment.repository.CommentRepository;
+import com.kakaotechcampus.team16be.post.domain.Post;
+import com.kakaotechcampus.team16be.post.service.PostService;
+import com.kakaotechcampus.team16be.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommentFacadeService {
+
+    private final CommentRepository commentRepository;
+    private final PostService postService;
+    private final CommentService commentService;
+
+
+    @Transactional
+    public Long createParentComment(User user, CommentRequest commentRequest) {
+        Post post = postService.findById(commentRequest.postId());
+
+        Comment parentComment = Comment.createComment(commentRequest.content(), post, user, null);
+        commentRepository.save(parentComment);
+        return parentComment.getId();
+    }
+
+    @Transactional
+    public Long createChildComment(User user,CommentRequest commentRequest) {
+        Post post = postService.findById(commentRequest.postId());
+
+        Comment comment = commentService.findById(commentRequest.parentId());
+
+        Comment childComment = Comment.createComment(commentRequest.content(), post, user, comment);
+
+        return commentRepository.save(childComment).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<Comment> getCommentsByPostId(Long postId) {
+        Post post = postService.findById(postId);
+        return commentRepository.findAllByPost(post);
+    }
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/comment/service/CommentService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/service/CommentService.java
@@ -8,13 +8,10 @@ import com.kakaotechcampus.team16be.user.domain.User;
 import java.util.List;
 
 public interface CommentService {
-    Long createParentComment(User user,CommentRequest commentRequest);
-
-    Long createChildComment(User user,CommentRequest commentRequest);
-
-    List<Comment> getCommentsByPostId(Long postId);
 
     Long updateComment(User user, CommentUpdateRequest commentUpdateRequest);
 
     void deleteComment(User user, Long commentId);
+
+    Comment findById(Long id);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/service/CommentServiceImpl.java
@@ -20,39 +20,12 @@ import java.util.List;
 public class CommentServiceImpl implements CommentService {
 
     private final CommentRepository commentRepository;
-    private final PostService postService;
 
 
-    @Transactional
-    @Override
-    public Long createParentComment(User user, CommentRequest commentRequest) {
-        Post post = postService.findById(commentRequest.postId());
-
-        Comment parentComment = Comment.createComment(commentRequest.content(), post, user, null);
-        commentRepository.save(parentComment);
-        return parentComment.getId();
-    }
-
-    @Override
-    @Transactional
-    public Long createChildComment(User user,CommentRequest commentRequest) {
-        Post post = postService.findById(commentRequest.postId());
-
-        Comment comment = findById(commentRequest.parentId());
-
-        Comment childComment = Comment.createComment(commentRequest.content(), post, user, comment);
-
-        return commentRepository.save(childComment).getId();
-    }
 
     @Override
     @Transactional(readOnly = true)
-    public List<Comment> getCommentsByPostId(Long postId) {
-        Post post = postService.findById(postId);
-        return commentRepository.findAllByPost(post);
-    }
-
-    private Comment findById(Long id) {
+    public Comment findById(Long id) {
         return commentRepository.findById(id)
                 .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
     }

--- a/src/main/java/com/kakaotechcampus/team16be/post/controller/PostController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/post/controller/PostController.java
@@ -6,6 +6,7 @@ import com.kakaotechcampus.team16be.post.dto.CreatePostRequest;
 import com.kakaotechcampus.team16be.post.dto.GetPostResponse;
 import com.kakaotechcampus.team16be.post.dto.PostIdResponse;
 import com.kakaotechcampus.team16be.post.dto.UpdatePostRequest;
+import com.kakaotechcampus.team16be.post.service.PostFacadeService;
 import com.kakaotechcampus.team16be.post.service.PostService;
 import com.kakaotechcampus.team16be.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,6 +25,7 @@ import java.util.List;
 public class PostController {
 
     private final PostService postService;
+    private final PostFacadeService postFacadeService;
 
     @Operation(summary = "게시글 생성", description = "새로운 게시글을 생성합니다.")
     @PostMapping("/posts")
@@ -35,14 +37,14 @@ public class PostController {
     @Operation(summary = "게시글 조회", description = "특정 게시글을 조회합니다.")
     @GetMapping("/{groupId}/posts/{postId}")
     public ResponseEntity<GetPostResponse> getPost(@LoginUser User user,@PathVariable Long groupId, @PathVariable Long postId) {
-        GetPostResponse PostResponse = postService.getPost(user,groupId, postId);
+        GetPostResponse PostResponse = postFacadeService.getPost(user,groupId, postId);
         return ResponseEntity.ok(PostResponse);
     }
 
     @Operation(summary = "게시글 전체 조회", description = "특정 그룹의 모든 게시글을 조회합니다.")
     @GetMapping("/{groupId}/posts")
     public ResponseEntity<List<GetPostResponse>> getAllPosts(@LoginUser User user, @PathVariable Long groupId) {
-        List<GetPostResponse> PostResponses = postService.getAllPosts(user, groupId);
+        List<GetPostResponse> PostResponses = postFacadeService.getAllPosts(user, groupId);
         return ResponseEntity.ok(PostResponses);
     }
 

--- a/src/main/java/com/kakaotechcampus/team16be/post/service/PostFacadeService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/post/service/PostFacadeService.java
@@ -1,0 +1,64 @@
+package com.kakaotechcampus.team16be.post.service;
+
+import com.kakaotechcampus.team16be.aws.service.S3UploadPresignedUrlService;
+import com.kakaotechcampus.team16be.comment.service.CommentFacadeService;
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.group.service.GroupService;
+import com.kakaotechcampus.team16be.like.dto.PostLikeResponse;
+import com.kakaotechcampus.team16be.like.service.PostLikeService;
+import com.kakaotechcampus.team16be.post.domain.Post;
+import com.kakaotechcampus.team16be.post.dto.GetPostResponse;
+import com.kakaotechcampus.team16be.post.exception.PostErrorCode;
+import com.kakaotechcampus.team16be.post.exception.PostException;
+import com.kakaotechcampus.team16be.post.repository.PostRepository;
+import com.kakaotechcampus.team16be.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostFacadeService {
+
+    private final GroupService groupService;
+    private final PostRepository postRepository;
+    private final CommentFacadeService commentFacadeService;
+    private final PostLikeService postLikeService;
+    private final S3UploadPresignedUrlService s3UploadPresignedUrlService;
+
+
+    @Transactional(readOnly = true)
+    public GetPostResponse getPost(User user, Long groupId, Long postId) {
+        Group targetGroup = groupService.findGroupById(groupId);
+        Post post = postRepository.findByIdAndGroup(postId, targetGroup)
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+
+        Integer commentCount = commentFacadeService.getCommentsByPostId(postId).size();
+        PostLikeResponse postLikeResponse = postLikeService.getPostLikeInfo(user, postId);
+
+        List<String> fullURLs = post.getImageUrls().stream()
+                .map(s3UploadPresignedUrlService::getPublicUrl)
+                .toList();
+
+        return GetPostResponse.from(post, fullURLs, commentCount, postLikeResponse.isLiked());
+    }
+
+    @Transactional(readOnly = true)
+    public List<GetPostResponse> getAllPosts(User user, Long groupId) {
+        Group targetGroup = groupService.findGroupById(groupId);
+        List<Post> posts = postRepository.findByGroup(targetGroup);
+
+        return posts.stream()
+                .map(post -> {
+                    List<String> fullURLs = post.getImageUrls().stream()
+                            .map(s3UploadPresignedUrlService::getPublicUrl)
+                            .toList();
+                    Integer commentCount = commentFacadeService.getCommentsByPostId(post.getId()).size();
+                    PostLikeResponse postLikeResponse = postLikeService.getPostLikeInfo(user, post.getId());
+                    return GetPostResponse.from(post, fullURLs, commentCount,postLikeResponse.isLiked());
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/post/service/PostService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/post/service/PostService.java
@@ -15,10 +15,6 @@ import java.util.List;
 public interface PostService {
     Post createPost(User user, CreatePostRequest createPostRequest);
 
-    GetPostResponse getPost(User user, Long groupId, Long postId);
-
-    List<GetPostResponse> getAllPosts(User user, Long groupId);
-
     void deletePost(User user, Long postId);
 
     Post findByAuthorAndId(User user, Long postId);


### PR DESCRIPTION
## 관련이슈
- close #126 

## 🔧 변경 사항

### CommentFacadeService 추가
- 부모/자식 댓글 생성 기능을 담당하도록 분리
- 댓글 조회 기능 포함
- CommentService와 PostService 의존만 유지 → 순환 참조 제거

### CommentController 수정
- 기존 CommentService 호출을 CommentFacadeService로 변경
- 댓글 생성/조회 시 Facade를 통해 로직 실행

### PostFacadeService 추가
- 게시글 단건 조회 및 전체 조회 기능 담당
- 댓글 개수 조회(CommentFacadeService) 및 좋아요 상태 조회(PostLikeService) 포함
- 기존 PostServiceImpl에서 담당하던 댓글 조회 로직 제거 → 순환 참조 제거

### PostController 수정
- 게시글 조회 API가 기존 PostService 호출 대신 PostFacadeService 호출하도록 변경

### PostService/Impl 변경
- 댓글 조회 로직(CommentService) 제거 → Facade로 위임
- 순환 참조 제거로 ApplicationContext 시작 에러 해결

### CommentService/Impl 수정
- 댓글 생성/조회 로직 유지
- 댓글 조회는 Repository 직접 호출
