### PR TITLE
refactor: 부모 댓글 생성 DTO와 자식 댓글 생성 DTO 분리

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/comment/controller/CommentController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/controller/CommentController.java
@@ -1,10 +1,7 @@
 package com.kakaotechcampus.team16be.comment.controller;
 
 import com.kakaotechcampus.team16be.comment.domain.Comment;
-import com.kakaotechcampus.team16be.comment.dto.CommentIdResponse;
-import com.kakaotechcampus.team16be.comment.dto.CommentRequest;
-import com.kakaotechcampus.team16be.comment.dto.CommentResponse;
-import com.kakaotechcampus.team16be.comment.dto.CommentUpdateRequest;
+import com.kakaotechcampus.team16be.comment.dto.*;
 import com.kakaotechcampus.team16be.comment.service.CommentFacadeService;
 import com.kakaotechcampus.team16be.comment.service.CommentService;
 import com.kakaotechcampus.team16be.common.annotation.LoginUser;
@@ -29,9 +26,9 @@ public class CommentController {
     @PostMapping("/comments")
     public ResponseEntity<CommentIdResponse> createParentComment(
             @LoginUser User user,
-            @RequestBody CommentRequest commentRequest
+            @RequestBody ParentCommentRequest parentCommentRequest
     ) {
-        Long commentId= commentFacadeService.createParentComment(user, commentRequest);
+        Long commentId= commentFacadeService.createParentComment(user, parentCommentRequest);
         return ResponseEntity.ok(CommentIdResponse.from(commentId));
     }
 
@@ -39,9 +36,9 @@ public class CommentController {
     @PostMapping("/comments/reply")
     public ResponseEntity<CommentIdResponse> createChildComment(
             @LoginUser User user,
-            @RequestBody CommentRequest commentRequest
+            @RequestBody ChildCommentRequest childCommentRequest
     ) {
-        Long commentId = commentFacadeService.createChildComment(user, commentRequest);
+        Long commentId = commentFacadeService.createChildComment(user, childCommentRequest);
         return ResponseEntity.ok(CommentIdResponse.from(commentId));
     }
 

--- a/src/main/java/com/kakaotechcampus/team16be/comment/dto/ChildCommentRequest.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/dto/ChildCommentRequest.java
@@ -1,6 +1,6 @@
 package com.kakaotechcampus.team16be.comment.dto;
 
-public record CommentRequest(
+public record ChildCommentRequest(
         Long groupId,
         Long postId,
         String content,

--- a/src/main/java/com/kakaotechcampus/team16be/comment/dto/ParentCommentRequest.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/dto/ParentCommentRequest.java
@@ -1,0 +1,7 @@
+package com.kakaotechcampus.team16be.comment.dto;
+
+public record ParentCommentRequest (
+        Long postId,
+        String content
+) {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/comment/service/CommentFacadeService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/service/CommentFacadeService.java
@@ -1,7 +1,8 @@
 package com.kakaotechcampus.team16be.comment.service;
 
 import com.kakaotechcampus.team16be.comment.domain.Comment;
-import com.kakaotechcampus.team16be.comment.dto.CommentRequest;
+import com.kakaotechcampus.team16be.comment.dto.ChildCommentRequest;
+import com.kakaotechcampus.team16be.comment.dto.ParentCommentRequest;
 import com.kakaotechcampus.team16be.comment.repository.CommentRepository;
 import com.kakaotechcampus.team16be.post.domain.Post;
 import com.kakaotechcampus.team16be.post.service.PostService;
@@ -22,21 +23,21 @@ public class CommentFacadeService {
 
 
     @Transactional
-    public Long createParentComment(User user, CommentRequest commentRequest) {
-        Post post = postService.findById(commentRequest.postId());
+    public Long createParentComment(User user, ParentCommentRequest parentCommentRequest) {
+        Post post = postService.findById(parentCommentRequest.postId());
 
-        Comment parentComment = Comment.createComment(commentRequest.content(), post, user, null);
+        Comment parentComment = Comment.createComment(parentCommentRequest.content(), post, user, null);
         commentRepository.save(parentComment);
         return parentComment.getId();
     }
 
     @Transactional
-    public Long createChildComment(User user,CommentRequest commentRequest) {
-        Post post = postService.findById(commentRequest.postId());
+    public Long createChildComment(User user, ChildCommentRequest childCommentRequest) {
+        Post post = postService.findById(childCommentRequest.postId());
 
-        Comment comment = commentService.findById(commentRequest.parentId());
+        Comment comment = commentService.findById(childCommentRequest.parentId());
 
-        Comment childComment = Comment.createComment(commentRequest.content(), post, user, comment);
+        Comment childComment = Comment.createComment(childCommentRequest.content(), post, user, comment);
 
         return commentRepository.save(childComment).getId();
     }

--- a/src/main/java/com/kakaotechcampus/team16be/comment/service/CommentService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/service/CommentService.java
@@ -1,11 +1,8 @@
 package com.kakaotechcampus.team16be.comment.service;
 
 import com.kakaotechcampus.team16be.comment.domain.Comment;
-import com.kakaotechcampus.team16be.comment.dto.CommentRequest;
 import com.kakaotechcampus.team16be.comment.dto.CommentUpdateRequest;
 import com.kakaotechcampus.team16be.user.domain.User;
-
-import java.util.List;
 
 public interface CommentService {
 

--- a/src/main/java/com/kakaotechcampus/team16be/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/service/CommentServiceImpl.java
@@ -1,19 +1,14 @@
 package com.kakaotechcampus.team16be.comment.service;
 
 import com.kakaotechcampus.team16be.comment.domain.Comment;
-import com.kakaotechcampus.team16be.comment.dto.CommentRequest;
 import com.kakaotechcampus.team16be.comment.dto.CommentUpdateRequest;
 import com.kakaotechcampus.team16be.comment.exception.CommentErrorCode;
 import com.kakaotechcampus.team16be.comment.exception.CommentException;
 import com.kakaotechcampus.team16be.comment.repository.CommentRepository;
-import com.kakaotechcampus.team16be.post.domain.Post;
-import com.kakaotechcampus.team16be.post.service.PostService;
 import com.kakaotechcampus.team16be.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
## 관련이슈
- close #130 

## 내용
- 부모 댓글과 자식 댓글이 동일 DTO를 사용하면서 부모 댓글 생성 요청에 parentId, groupId가 불필요하게 포함되는 문제를 수정하였습니다. 
- 부모 댓글 작성 시 parentId는 자동으로 null 처리되므로 Request에서 제외하였습니다.