### PR TITLE
refactor: 게시글 좋아요 취소 API PathVariable 방식으로 변경

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/like/controller/PostLikeController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/like/controller/PostLikeController.java
@@ -27,9 +27,12 @@ public class PostLikeController {
     }
 
     @Operation(summary = "게시글 좋아요 취소", description = "사용자가 특정 게시글에 눌렀던 좋아요를 취소합니다.")
-    @DeleteMapping("/likes")
-    public ResponseEntity<Void> unlikePost(@LoginUser User user, @RequestBody PostLikeRequest postLikeRequest) {
-        postLikeService.unlikePost(user, postLikeRequest);
+    @DeleteMapping("/{postId}/likes")
+    public ResponseEntity<Void> unlikePost(
+            @LoginUser User user,
+            @PathVariable Long postId
+    ) {
+        postLikeService.unlikePost(user, postId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/kakaotechcampus/team16be/like/service/PostLikeService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/like/service/PostLikeService.java
@@ -7,7 +7,7 @@ import com.kakaotechcampus.team16be.user.domain.User;
 public interface PostLikeService {
     void likePost(User user, PostLikeRequest postLikeRequest);
 
-    void unlikePost(User user, PostLikeRequest postLikeRequest);
+    void unlikePost(User user, Long postId);
 
     PostLikeResponse getPostLikeInfo(User user, Long postId);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/like/service/PostLikeServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/like/service/PostLikeServiceImpl.java
@@ -32,8 +32,8 @@ public class PostLikeServiceImpl implements  PostLikeService {
 
     @Override
     @Transactional
-    public void unlikePost(User user, PostLikeRequest postLikeRequest) {
-        Post post = postService.findById(postLikeRequest.postId());
+    public void unlikePost(User user, Long postId) {
+        Post post = postService.findById(postId);
         post.decreaseLikeCount();
         Like postLike = findByUserAndPost(user, post);
         postLikeRepository.delete(postLike);


### PR DESCRIPTION
## 관련이슈
- close #132 

## 내용
- 기존 좋아요 취소 API에서 postId를 Request Body로 전달하던 방식을 제거하고 @PathVariable로 변경하였습니다.
- DELETE /api/posts/{postId}/likes 형태로 수정하여 RESTful하게 개선하였습니다.