### PR TITLE
refactor: 생성/수정 ResponseDto 응답값 제거

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/plan/PlanController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/PlanController.java
@@ -5,6 +5,7 @@ import com.kakaotechcampus.team16be.plan.dto.PlanRequestDto;
 import com.kakaotechcampus.team16be.plan.dto.PlanResponseDto;
 import com.kakaotechcampus.team16be.plan.service.PlanService;
 import com.kakaotechcampus.team16be.user.domain.User;
+import java.net.URI;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -31,12 +32,16 @@ public class PlanController {
 
   @Operation(summary = "일정 생성", description = "그룹 내에서 새로운 일정을 생성합니다.")
   @PostMapping("/groups/{groupId}/plans")
-  public ResponseEntity<PlanResponseDto> createPlan(
+  public ResponseEntity<Long> createPlan(
       @LoginUser User user,
       @PathVariable Long groupId,
       @RequestBody PlanRequestDto planRequestDto){
-    return ResponseEntity.status(HttpStatus.CREATED).body(planService.createPlan(user, groupId, planRequestDto));
+    Long planId = planService.createPlan(user, groupId, planRequestDto);
+    URI location = URI.create(String.format("/api/groups/%d/plans/%d", groupId, planId));
+    return ResponseEntity.created(location).build();
   }
+
+
 
   @Operation(summary = "일정 조회", description = "특정 그룹 내 일정 하나를 조회합니다.")
   @GetMapping("/groups/{groupId}/plans/{planId}")
@@ -56,13 +61,14 @@ public class PlanController {
 
   @Operation(summary = "일정 수정", description = "특정 그룹 내 일정을 수정합니다.")
   @PatchMapping("/groups/{groupId}/plans/{planId}")
-  public ResponseEntity<PlanResponseDto> updatePlan(
+  public ResponseEntity<Void> updatePlan(
       @LoginUser User user,
       @PathVariable Long groupId,
       @PathVariable Long planId,
       @RequestBody PlanRequestDto planRequestDto
   ){
-    return ResponseEntity.status(HttpStatus.OK).body(planService.updatePlan(user, groupId, planId, planRequestDto));
+    planService.updatePlan(user, groupId, planId, planRequestDto);
+    return ResponseEntity.ok().build();
   }
 
   @Operation(summary = "일정 삭제", description = "특정 그룹 내 일정을 삭제합니다.")

--- a/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanService.java
@@ -9,10 +9,10 @@ import java.util.List;
 
 public interface PlanService {
 
-  PlanResponseDto createPlan(User user, Long groupId, PlanRequestDto planRequestDto);
+  Long createPlan(User user, Long groupId, PlanRequestDto planRequestDto);
   PlanResponseDto getPlan(Long groupId, Long planId);
   List<PlanResponseDto> getAllPlans(Long groupId);
-  PlanResponseDto updatePlan(User user, Long groupId, Long planId, PlanRequestDto planRequestDto);
+  void updatePlan(User user, Long groupId, Long planId, PlanRequestDto planRequestDto);
   void deletePlan(User user, Long groupId, Long planId);
   Plan findByGroupIdAndPlanId(Long groupId, Long planId);
   Plan findById(Long planId);

--- a/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/plan/service/PlanServiceImpl.java
@@ -32,7 +32,7 @@ public class PlanServiceImpl implements PlanService {
 
   @Override
   @Transactional
-  public PlanResponseDto createPlan(User user, Long groupId, PlanRequestDto planRequestDto) {
+  public Long createPlan(User user, Long groupId, PlanRequestDto planRequestDto) {
 
     Group group = groupService.findGroupById(groupId);
     group.checkLeader(user);
@@ -54,7 +54,7 @@ public class PlanServiceImpl implements PlanService {
                     .build();
 
     Plan savedPlan = planRepository.save(plan);
-    return PlanResponseDto.from(savedPlan);
+    return savedPlan.getId();
   }
 
   @Override
@@ -74,7 +74,7 @@ public class PlanServiceImpl implements PlanService {
 
   @Override
   @Transactional
-  public PlanResponseDto updatePlan(User user, Long groupId, Long planId, PlanRequestDto planRequestDto) {
+  public void updatePlan(User user, Long groupId, Long planId, PlanRequestDto planRequestDto) {
     Group group = groupService.findGroupById(groupId);
     group.checkLeader(user);
 
@@ -85,7 +85,6 @@ public class PlanServiceImpl implements PlanService {
       List<GroupMember> members = groupMemberService.findByGroup(plan.getGroup());
 
     notificationService.createPlanUpdateNotifications(plan,members);
-    return PlanResponseDto.from(plan);
   }
 
   @Override


### PR DESCRIPTION
프론트와 협의 후 plan 도메인의 responseDto의 응답값을 수정하였습니다.

1. CREATED(생성) 
**[기존]**
<img width="1602" height="1357" alt="image" src="https://github.com/user-attachments/assets/dc46dea0-9d25-416e-a7b8-69cfc524f941" />

**[변경]**
<img width="1589" height="919" alt="image" src="https://github.com/user-attachments/assets/5da21e4c-c01e-460d-aab7-09dfd166aeda" />
-> void로 처리

2.Update(수정)
-> 생성과 동일하게 void로 처리