### PR TITLE
feat: 전역 예외 처리에 Unexpected Exception 핸들링 추가 및 로깅 설정

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakaotechcampus/team16be/common/exception/GlobalExceptionHandler.java
@@ -1,9 +1,12 @@
 package com.kakaotechcampus.team16be.common.exception;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -12,5 +15,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(e.getStatus())
                 .body(new ErrorResponseDto(e.getMessage(), e.getCode(), e.getStatus()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponseDto> handleException(Exception e) {
+        log.error("예상치 못한 서버 오류 발생!!", e);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponseDto(
+                        "예상치 못한 서버 오류가 발생했습니다.",
+                        "UNEXPECTED_ERROR",
+                        HttpStatus.INTERNAL_SERVER_ERROR.value()
+                ));
     }
 }


### PR DESCRIPTION
### 관련이슈
- close #142 
### 변경 내용
- GlobalExceptionHandler에 @ExceptionHandler(Exception.class) 추가
  - 예상치 못한 예외(NullPointerException 등)도 일관된 응답 포맷으로 반환
- Slf4j 로깅 적용
  - 운영 환경에서도 예외 로그가 안전하게 남도록 개선

### 변경 이유
- BaseException 외의 시스템 예외도 클라이언트에 표준화된 에러 응답을 제공하기 위함
- 로깅을 통해 장애 상황을 추적 가능하게 하여 안정성 확보

### 참고
- 에러 응답 포맷: ErrorResponseDto(message, code, status)
- UNEXPECTED_ERROR 코드로 처리