### PR TITLE
fix:getAllAttends 조회 권한 삭제

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/attend/service/AttendServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/attend/service/AttendServiceImpl.java
@@ -41,15 +41,9 @@ public class AttendServiceImpl implements AttendService{
         return attendRepository.save(attend);
     }
 
-    /***
-     *  조회 권한은 그룹장만 가능?
-     */
     @Transactional(readOnly = true)
     @Override
     public List<Attend> getAllAttends(User user, Long groupId, Long planId) {
-        Group targetGroup = groupService.findGroupById(groupId);
-
-        targetGroup.checkLeader(user);
         Plan plan = planService.findByGroupIdAndPlanId(groupId, planId);
 
         return attendRepository.findAllByPlan(plan);


### PR DESCRIPTION
getAllAttends 조회 권한을
기존 그룹장에서 그룹에 해당하는 회원이 조회할 수 있도록 수정했습니다

- close #147 
