### PR TITLE
feat: 카카오 로그인 연결

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/controller/AuthController.java
@@ -23,13 +23,22 @@ public class AuthController {
     private final KakaoAuthService kakaoAuthService;
     private final UserService userService;
 
-    @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 받아 로그인 처리 후 토큰을 반환합니다.")
-    @GetMapping("/kakao-login")
+//    @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 받아 로그인 처리 후 토큰을 반환합니다.")
+//    @GetMapping("/kakao-login")
+//    public ResponseEntity<KakaoLoginResponse> kakaoLogin(
+//            @RequestParam("code") String code,
+//            HttpServletRequest request
+//    ) {
+//        KakaoLoginResponse kakaoLoginResponse = kakaoAuthService.loginWithCode(code, request);
+//        return ResponseEntity.ok(kakaoLoginResponse);
+//    }
+
+    @Operation(summary = "카카오 로그인(임시)", description = "프론트에서 받은 인가 코드를 통해 로그인 처리 후 토큰 반환")
+    @PostMapping("/kakao-login")
     public ResponseEntity<KakaoLoginResponse> kakaoLogin(
-            @RequestParam("code") String code,
-            HttpServletRequest request
+            @RequestParam("code") String code
     ) {
-        KakaoLoginResponse kakaoLoginResponse = kakaoAuthService.loginWithCode(code, request);
+        KakaoLoginResponse kakaoLoginResponse = kakaoAuthService.loginWithCode(code, null);
         return ResponseEntity.ok(kakaoLoginResponse);
     }
 


### PR DESCRIPTION
### 관련이슈
- close #158 

### 내용
프론트의 배포 주소가 계속 바뀌기 때문에 기존 하기로 했던 쿠키로 전달해주는 방식이 불가능하여 일시적으로 시연하기 위해서 POST로 변경하였습니다. 프론트가 인가코드를 던져줍니다.