### PR TITLE
bugfix: presigned URL 발급 방식을 groupId/postId 기반에서 UUID 기반으로 변경 (그룹/게시글 이미지 presigned URL 발급 API)

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/aws/controller/ImageController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/controller/ImageController.java
@@ -31,30 +31,27 @@ public class ImageController {
     }
 
     @Operation(summary = "S3 그룹 이미지 주소 요청", description = "이미지 업로드할 그룹 이미지 presigned-url을 반환합니다.")
-    @PostMapping("/presigned/groups/{groupId}")
+    @PostMapping("/presigned/groups")
     public ResponseEntity<ImageUrlDto> createGroupIconPresignedUrl(
             @LoginUser User user,
-            @PathVariable Long groupId,
             @RequestBody IssuePresignedUrlRequest request
     ) {
         ImageUrlDto imageUrlDto = s3UploadPresignedUrlService.executeGroupImg(
-                user,groupId, request.fileExtension());
+                user, request.fileExtension());
         return ResponseEntity.ok(imageUrlDto);
     }
 
     @Operation(summary = "S3 게시글 이미지 주소 요청", description = "게시글 이미지 업로드할 presigned-url을 반환합니다.")
-    @PostMapping("/presigned/group/{groupId}/posts/{postId}")
+    @PostMapping("/presigned/group/{groupId}/posts")
     public ResponseEntity<ImageUrlDto> createPostImgPresignedUrls(
             @LoginUser User user,
             @PathVariable Long groupId,
-            @PathVariable Long postId,
             @RequestBody IssuePresignedUrlRequest request
     ) {
 
         ImageUrlDto imageURlDto = s3UploadPresignedUrlService.executePostImg(
                 user,
                 groupId,
-                postId,
                 request.fileExtension()
         );
         return ResponseEntity.ok(imageURlDto);

--- a/src/main/java/com/kakaotechcampus/team16be/aws/service/S3UploadPresignedUrlService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/service/S3UploadPresignedUrlService.java
@@ -108,11 +108,11 @@ public class S3UploadPresignedUrlService {
         return amazonS3Client.generatePresignedUrl(request).toString();
     }
 
-    public ImageUrlDto executeGroupImg(User user, Long groupId, ImageFileExtension fileExtension) {
-
+    public ImageUrlDto executeGroupImg(User user, ImageFileExtension fileExtension) {
+        String groupUUID = UUID.randomUUID().toString();
         String valueFileExtension = fileExtension.getUploadExtension();
         String valueType = String.valueOf(ImageUploadType.GROUP_ICON);
-        String fileName = createGroupFileName(groupId, valueFileExtension, valueType);
+        String fileName = createGroupFileName(groupUUID, valueFileExtension, valueType);
         log.info(fileName);
 
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
@@ -122,17 +122,18 @@ public class S3UploadPresignedUrlService {
         return ImageUrlDto.of(url.toString(), fileName);
     }
 
-    private String createGroupFileName(Long groupId, String fileExtension, String valueType) {
-        return valueType + "/" + groupId + "/" + UUID.randomUUID() + "." + fileExtension;
+    private String createGroupFileName(String groupUUID, String fileExtension, String valueType) {
+        return valueType + "/" + groupUUID + "/" + UUID.randomUUID() + "." + fileExtension;
     }
 
-    public ImageUrlDto executePostImg(User user, Long groupId, Long postId, ImageFileExtension fileExtension) {
-
+    public ImageUrlDto executePostImg(User user, Long groupId, ImageFileExtension fileExtension) {
         Group targetGroup = groupService.findGroupById(groupId);
         targetGroup.checkLeader(user);
+
+        String postUUID = UUID.randomUUID().toString();
         String valueFileExtension = fileExtension.getUploadExtension();
         String valueType = String.valueOf(ImageUploadType.POST);
-        String fileName = createPostFileName(groupId, postId, valueFileExtension, valueType);
+        String fileName = createPostFileName(groupId, postUUID, valueFileExtension, valueType);
         log.info(fileName);
 
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
@@ -142,7 +143,7 @@ public class S3UploadPresignedUrlService {
         return ImageUrlDto.of(url.toString(), fileName);
     }
 
-    private String createPostFileName(Long groupId, Long postId, String fileExtension,String valueType) {
-        return valueType + "/" + groupId + "/" + postId + "/" + UUID.randomUUID() + "." + fileExtension;
+    private String createPostFileName(Long groupId, String postUUID, String fileExtension,String valueType) {
+        return valueType + "/" + groupId + "/" + postUUID + "/" + UUID.randomUUID() + "." + fileExtension;
     }
 }


### PR DESCRIPTION
### 관련 이슈
- close #119 

### 문제 상황 
문제 되는 api는 다음 두 개입니다.
1. S3 그룹 이미지 주소 요청 -> /api/image/presigned/groups/{groupId}
2. S3 게시글 이미지 주소 요청 -> /api/image/presigned/group/{groupId}/posts/{postId}
- /presigned/groups/{groupId} API는 그룹 아이콘 presigned URL 발급을 위해 groupId가 필요합니다.
- 그룹 생성 시점에는 groupId가 존재하지 않음 → API 호출 불가능.
- 동일하게 /presigned/group/{groupId}/posts/{postId}도 게시글 생성 전에는 postId가 없으므로 문제가 있습니다.

### 바꾸기로 한 방법
1. S3 그룹 이미지 주소 요청 -> /api/image/presigned/groups
2. S3 게시글 이미지 주소 요청 -> /api/image/presigned/group/{groupId}/posts
- 둘 다 기존에는 groupId, postId와 같이 고유 기본키를 받아서 그걸 기반으로 S3 경로를 만들어서 저장하는 방식이었는데 그거 안받고 그냥 서버에서 UUID 발급해서 그걸로 저장합니다.

### 변경 사항 정리
- presigned URL 발급 시 groupId, postId 대신 UUID 기반 경로를 사용하도록 수정
- API 변경
  - 그룹 이미지: /presigned/groups
  - 게시글 이미지: /presigned/group/{groupId}/posts
- 서비스 로직 수정
  - S3 경로를 UUID 기반으로 생성
  - DB ID와 무관하게 업로드 가능