### PR TITLE
feat: 채팅방 CRUD 구현 및 실시간 메시지 기능 구현을 위한 WebSocket 설정 및 ChatRoomMessage 엔티티 미리 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,15 @@ dependencies {
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
+    // WebSocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    // sockjs
+    implementation 'org.webjars:sockjs-client:1.5.1'
+    // stomp
+    implementation 'org.webjars:stomp-websocket:2.3.4'
+    // gson
+    implementation 'com.google.code.gson:gson:2.9.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/controller/ChatRoomController.java
@@ -1,0 +1,50 @@
+package com.kakaotechcampus.team16be.chatroom.controller;
+
+
+import com.kakaotechcampus.team16be.chatroom.domain.ChatRoom;
+import com.kakaotechcampus.team16be.chatroom.dto.CreateChatRoomDto;
+import com.kakaotechcampus.team16be.chatroom.dto.ResponseChatRoomDto;
+import com.kakaotechcampus.team16be.chatroom.dto.UpdateChatRoomDto;
+import com.kakaotechcampus.team16be.chatroom.service.ChatRoomService;
+import com.kakaotechcampus.team16be.common.annotation.LoginUser;
+import com.kakaotechcampus.team16be.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/group")
+@RequiredArgsConstructor
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    @GetMapping("/{groupId}/chat")
+    public ResponseEntity<List<ResponseChatRoomDto>> getAllChatRooms(@LoginUser User user, @PathVariable Long groupId) {
+        List<ChatRoom> chatRooms = chatRoomService.getAllChatRooms(user, groupId);
+        return ResponseEntity.ok(ResponseChatRoomDto.from(chatRooms));
+    }
+
+    @PostMapping("/{groupId}/chat")
+    public ResponseEntity<ResponseChatRoomDto> createChatRoom(@LoginUser User user, @PathVariable Long groupId, @RequestBody CreateChatRoomDto createChatRoomDto) {
+        ChatRoom chatRoom = chatRoomService.createChatRoom(user, groupId, createChatRoomDto);
+
+        return ResponseEntity.ok(ResponseChatRoomDto.from(chatRoom));
+    }
+
+    @PutMapping("/{groupId}/chat/{chatRoomId}")
+    public ResponseEntity<ResponseChatRoomDto> updateChatRoom(@LoginUser User user, @PathVariable Long groupId, @RequestBody UpdateChatRoomDto updateChatRoomDto, @PathVariable Long chatRoomId) {
+        ChatRoom chatRoom = chatRoomService.updateChatRoom(user, groupId, updateChatRoomDto, chatRoomId);
+
+        return ResponseEntity.ok(ResponseChatRoomDto.from(chatRoom));
+    }
+
+    @DeleteMapping("/{groupId}/chat/{chatRoomId}")
+    public ResponseEntity<Void> deleteChatRoom(@LoginUser User user, @PathVariable Long groupId, @PathVariable Long chatRoomId) {
+        chatRoomService.deleteChatRoom(user, groupId, chatRoomId);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/domain/ChatRoom.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/domain/ChatRoom.java
@@ -1,0 +1,57 @@
+package com.kakaotechcampus.team16be.chatroom.domain;
+
+import com.kakaotechcampus.team16be.chatroom.exception.ChatRoomErrorCode;
+import com.kakaotechcampus.team16be.chatroom.exception.ChatRoomException;
+import com.kakaotechcampus.team16be.common.BaseEntity;
+import com.kakaotechcampus.team16be.group.domain.Group;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom extends BaseEntity {
+
+    @Id
+    @Column(name = "room_id")
+    private String id;
+
+    @Column(name = "room_name", nullable = false)
+    private String roomName;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @Column(name = "group_id", nullable = false)
+    private Group group;
+
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ChatRoomUser> participants = new HashSet<>();
+
+    public static ChatRoom create(String roomName) {
+        ChatRoom chatRoom = new ChatRoom();
+        chatRoom.id = UUID.randomUUID().toString();
+        chatRoom.roomName = roomName;
+        return chatRoom;
+    }
+
+    public long getUserCount() {
+        return this.participants.size();
+    }
+
+    public void checkGroup(Group targetGroup) {
+        if(!this.group.equals(targetGroup)) {
+            throw new ChatRoomException(ChatRoomErrorCode.CHATROOM_GROUP_MISMATCH);
+        }
+    }
+
+    public ChatRoom updateName(String roomName) {
+        this.roomName = roomName;
+        return this;
+
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/domain/ChatRoom.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/domain/ChatRoom.java
@@ -26,7 +26,7 @@ public class ChatRoom extends BaseEntity {
     private String roomName;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @Column(name = "group_id", nullable = false)
+    @JoinColumn(name = "group_id", nullable = false)
     private Group group;
 
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/domain/ChatRoomMessage.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/domain/ChatRoomMessage.java
@@ -1,0 +1,25 @@
+package com.kakaotechcampus.team16be.chatroom.domain;
+
+import com.kakaotechcampus.team16be.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomMessage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+
+    private String message;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_user_id")
+    private ChatRoomUser chatRoomUser;
+}

--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/domain/ChatRoomUser.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/domain/ChatRoomUser.java
@@ -1,0 +1,27 @@
+package com.kakaotechcampus.team16be.chatroom.domain;
+
+import com.kakaotechcampus.team16be.common.BaseEntity;
+import com.kakaotechcampus.team16be.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomUser extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_room_user_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/dto/CreateChatRoomDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/dto/CreateChatRoomDto.java
@@ -1,0 +1,6 @@
+package com.kakaotechcampus.team16be.chatroom.dto;
+
+public record CreateChatRoomDto(
+        String name
+) {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/dto/ResponseChatRoomDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/dto/ResponseChatRoomDto.java
@@ -1,0 +1,30 @@
+package com.kakaotechcampus.team16be.chatroom.dto;
+
+import com.kakaotechcampus.team16be.chatroom.domain.ChatRoom;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ResponseChatRoomDto(
+        String id,
+        String roomName,
+        LocalDateTime createdAt
+) {
+    public static List<ResponseChatRoomDto> from(List<ChatRoom> chatRooms) {
+        return chatRooms.stream()
+                .map(chatRoom -> new ResponseChatRoomDto(
+                        chatRoom.getId(),
+                        chatRoom.getRoomName(),
+                        chatRoom.getCreatedAt()))
+                .toList();
+    }
+
+    public static ResponseChatRoomDto from(ChatRoom chatRoom) {
+        return new ResponseChatRoomDto(
+                chatRoom.getId(),
+                chatRoom.getRoomName(),
+                chatRoom.getCreatedAt()
+        );
+    }
+}
+

--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/dto/UpdateChatRoomDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/dto/UpdateChatRoomDto.java
@@ -1,0 +1,6 @@
+package com.kakaotechcampus.team16be.chatroom.dto;
+
+public record UpdateChatRoomDto(
+        String name
+){
+}

--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/exception/ChatRoomErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/exception/ChatRoomErrorCode.java
@@ -1,0 +1,17 @@
+package com.kakaotechcampus.team16be.chatroom.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatRoomErrorCode {
+
+    CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CR-001", "채팅방을 찾을 수 없습니다."),
+    CHATROOM_GROUP_MISMATCH(HttpStatus.BAD_REQUEST, "CR-002", "해당 그룹의 채팅방이 아닙니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/exception/ChatRoomException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/exception/ChatRoomException.java
@@ -1,0 +1,28 @@
+package com.kakaotechcampus.team16be.chatroom.exception;
+
+import com.kakaotechcampus.team16be.common.exception.BaseException;
+import lombok.Getter;
+
+@Getter
+public class ChatRoomException extends BaseException {
+    private final ChatRoomErrorCode errorCode;
+
+    public ChatRoomException(ChatRoomErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+
+    @Override
+    public String getCode() {
+        return errorCode.getCode();
+    }
+
+    @Override
+    public int getStatus() {
+        return errorCode.getStatus().value();
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/repository/ChatRoomRepository.java
@@ -1,0 +1,14 @@
+package com.kakaotechcampus.team16be.chatroom.repository;
+
+import com.kakaotechcampus.team16be.chatroom.domain.ChatRoom;
+import com.kakaotechcampus.team16be.group.domain.Group;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChatRoomRepository extends CrudRepository<ChatRoom, Long> {
+    List<ChatRoom> findChatRoomsByGroup(Group group);
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/service/ChatRoomService.java
@@ -1,0 +1,19 @@
+package com.kakaotechcampus.team16be.chatroom.service;
+
+import com.kakaotechcampus.team16be.chatroom.dto.CreateChatRoomDto;
+import com.kakaotechcampus.team16be.chatroom.domain.ChatRoom;
+import com.kakaotechcampus.team16be.chatroom.dto.UpdateChatRoomDto;
+import com.kakaotechcampus.team16be.user.domain.User;
+
+import java.util.List;
+
+public interface ChatRoomService {
+    List<ChatRoom> getAllChatRooms(User user, Long groupId);
+
+    ChatRoom createChatRoom(User user, Long groupId, CreateChatRoomDto createChatRoomDto);
+
+    ChatRoom updateChatRoom(User user, Long groupId, UpdateChatRoomDto updateChatRoomDto, Long chatRoomId);
+
+    void deleteChatRoom(User user, Long groupId, Long chatRoomId);
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/service/ChatRoomServiceImpl.java
@@ -1,0 +1,80 @@
+package com.kakaotechcampus.team16be.chatroom.service;
+
+import com.kakaotechcampus.team16be.chatroom.dto.CreateChatRoomDto;
+import com.kakaotechcampus.team16be.chatroom.domain.ChatRoom;
+import com.kakaotechcampus.team16be.chatroom.dto.UpdateChatRoomDto;
+import com.kakaotechcampus.team16be.chatroom.exception.ChatRoomErrorCode;
+import com.kakaotechcampus.team16be.chatroom.exception.ChatRoomException;
+import com.kakaotechcampus.team16be.chatroom.repository.ChatRoomRepository;
+
+import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.group.service.GroupService;
+import com.kakaotechcampus.team16be.groupMember.service.GroupMemberService;
+import com.kakaotechcampus.team16be.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomServiceImpl implements ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final GroupMemberService groupMemberService;
+    private final GroupService groupService;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<ChatRoom> getAllChatRooms(User user, Long groupId) {
+        Group targetGroup  = groupService.findGroupById(groupId);
+        groupMemberService.validateGroupMember(user,groupId);
+
+        List<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsByGroup(targetGroup);
+
+        return chatRoomRepository.findChatRoomsByGroup(targetGroup);
+    }
+
+    @Transactional
+    @Override
+    public ChatRoom createChatRoom(User user, Long groupId, CreateChatRoomDto createChatRoomDto) {
+        Group targetGroup  = groupService.findGroupById(groupId);
+        targetGroup.checkLeader(user);
+
+        ChatRoom createdChatRoom = ChatRoom.create(createChatRoomDto.name());
+
+        return chatRoomRepository.save(createdChatRoom);
+    }
+
+    @Transactional
+    @Override
+    public ChatRoom updateChatRoom(User user, Long groupId, UpdateChatRoomDto updateChatRoomDto, Long chatRoomId) {
+        Group targetGroup  = groupService.findGroupById(groupId);
+        targetGroup.checkLeader(user);
+
+        ChatRoom targetRoom = findChatRoomById(chatRoomId);
+        targetRoom.checkGroup(targetGroup);
+
+        ChatRoom updatedRoom = targetRoom.updateName(updateChatRoomDto.name());
+
+        return chatRoomRepository.save(updatedRoom);
+    }
+
+    public ChatRoom findChatRoomById(long chatRoomId) {
+        return chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+    }
+
+    public void deleteChatRoom(User user, Long groupId, Long chatRoomId) {
+        Group targetGroup  = groupService.findGroupById(groupId);
+        targetGroup.checkLeader(user);
+
+        ChatRoom targetRoom = findChatRoomById(chatRoomId);
+        targetRoom.checkGroup(targetGroup);
+
+        chatRoomRepository.delete(targetRoom);
+    }
+
+
+}

--- a/src/main/java/com/kakaotechcampus/team16be/common/config/WebSocketConfig.java
+++ b/src/main/java/com/kakaotechcampus/team16be/common/config/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package com.kakaotechcampus.team16be.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker //WebSocket의 메세지 처리를 활성화합니다.(카카오톡의 "실시간 메시지 기능 ON" 스위치를 켜는 것)
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) { //메세지 브로커를 설정하는 메소드
+        config.enableSimpleBroker("/topic", "/queue"); // 구독자에게 전송되는 경로
+        config.setApplicationDestinationPrefixes("/app"); // 클라이언트가 보내는 메시지 경로 접두사
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry){ //STOMP 접속 지점을 등록하는 메소드
+        registry.addEndpoint("/ws") // 클라이언트 접속 URL
+                .setAllowedOriginPatterns("*") // CORS 허용(와일드 카드)
+                .withSockJS();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #165 

## 구현 사항

### 도메인
- **ChatRoom**: 채팅방 엔티티, ID, 이름, 그룹, 참여자 관리, 생성/수정/그룹 검증 메서드 포함
- **ChatRoomUser**: 채팅방 참여자 엔티티, ChatRoom ↔ User 다대다 관계 매핑
- **ChatRoomMessage**: 채팅 메시지 엔티티, 채팅방, 메시지 내용, 작성자 연관관계 포함

### DTO
- **ResponseChatRoomDto**: ChatRoom → API 응답 변환
- **CreateChatRoomDto**: 채팅방 생성 요청 DTO
- **UpdateChatRoomDto**: 채팅방 이름 수정 요청 DTO

### Repository
- **ChatRoomRepository**: 그룹별 채팅방 조회 메서드(`findChatRoomsByGroup`) 제공

### Service
- **ChatRoomService** 인터페이스: 채팅방 CRUD 메서드 정의
- **ChatRoomServiceImpl**: CRUD 로직 구현, 권한 체크 포함

### Controller
- **ChatRoomController**: REST API 제공 (`GET/POST/PUT/DELETE /api/group/{groupId}/chat`), DTO 변환 후 JSON 응답

### WebSocket
- **WebSocketConfig**: `/ws` 엔드포인트 등록, 브로커 설정(`/topic`, `/queue`), 클라이언트 메시지 접두사 `/app`, SockJS 지원
- **동작 흐름**
  1. 클라이언트가 `/ws`로 STOMP 연결
  2. 클라이언트가 `/topic/chat/{roomId}` 구독
  3. 클라이언트가 `/app/chat/message` 전송 → 서버의 `@MessageMapping` 실행
  4. 서버가 `messagingTemplate.convertAndSend("/topic/chat/{roomId}", msg)`로 메시지 전달

### 예외 처리
- **ChatRoomException**: ChatRoom 관련 전용 예외, 메시지/코드/HTTP 상태 반환

### 의존성 추가
- Spring WebSocket
- SockJS
- STOMP
- Gson

## 실시간 채팅을 위해 추후 해야 할 것
1. 서버
- @MessageMapping 핸들러 구현
- 메시지 DB 저장 + 브로드캐스트
- 참여자 접속/퇴장 관리
2. DB
- 채팅 메시지 저장
- 참여자 상태 관리 (옵션: Redis)
3. 인증/권한
- WebSocket 연결 인증
- 메시지 전송 권한 체크
4. 성능/예외
- 브로드캐스트 최적화
- 연결/메시지 예외 처리
