### PR TITLE
feat:유저 정보 조회

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/controller/GroupMemberController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/controller/GroupMemberController.java
@@ -7,6 +7,7 @@ import com.kakaotechcampus.team16be.groupMember.dto.*;
 import com.kakaotechcampus.team16be.groupMember.service.GroupMemberService;
 import com.kakaotechcampus.team16be.groupMember.service.GroupMemberFacade;
 import com.kakaotechcampus.team16be.user.domain.User;
+import com.kakaotechcampus.team16be.groupMember.dto.GroupMemberInfoDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/GroupMemberInfoDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/GroupMemberInfoDto.java
@@ -1,0 +1,37 @@
+package com.kakaotechcampus.team16be.groupMember.dto;
+
+import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
+import com.kakaotechcampus.team16be.groupMember.domain.GroupRole;
+import com.kakaotechcampus.team16be.user.domain.User;
+import com.kakaotechcampus.team16be.user.domain.VerificationStatus;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record GroupMemberInfoDto(
+        Long userId,
+        VerificationStatus verificationStatus,
+        List<GroupRoleDto> groups
+) {
+    public static GroupMemberInfoDto from(User user, List<GroupMember> members) {
+        List<GroupRoleDto> groupRoleDtos = members.stream()
+                .map(GroupRoleDto::from)
+                .collect(Collectors.toList());
+
+        return new GroupMemberInfoDto(user.getId(), user.getVerificationStatus(), groupRoleDtos);
+    }
+
+    public record GroupRoleDto(
+            Long groupId,
+            String groupName,
+            GroupRole role
+    ) {
+        public static GroupRoleDto from(GroupMember member) {
+            return new GroupRoleDto(
+                    member.getGroup().getId(),
+                    member.getGroup().getName(),
+                    member.getRole()
+            );
+        }
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/repository/GroupMemberRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/repository/GroupMemberRepository.java
@@ -17,4 +17,6 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember,Long> {
     List<GroupMember> findAllByGroup(Group group);
 
     List<GroupMember> findAllByGroupAndStatus(Group group, GroupMemberStatus status);
+
+    List<GroupMember> findAllByUser(User user);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberService.java
@@ -3,6 +3,7 @@ package com.kakaotechcampus.team16be.groupMember.service;
 import com.kakaotechcampus.team16be.group.domain.Group;
 import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
 import com.kakaotechcampus.team16be.user.domain.User;
+import com.kakaotechcampus.team16be.groupMember.dto.GroupMemberInfoDto;
 
 import java.util.List;
 
@@ -23,4 +24,8 @@ public interface GroupMemberService {
     void validateGroupMember(User user, Long groupId);
 
     List<GroupMember> findByGroupAndPendingUser(User user, Long groupId);
+
+    List<GroupMember> findByUser(User user);
+
+    GroupMemberInfoDto getUserInfo(User user);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
@@ -6,6 +6,7 @@ import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
 import com.kakaotechcampus.team16be.groupMember.exception.GroupMemberException;
 import com.kakaotechcampus.team16be.groupMember.repository.GroupMemberRepository;
 import com.kakaotechcampus.team16be.user.domain.User;
+import com.kakaotechcampus.team16be.groupMember.dto.GroupMemberInfoDto;
 import com.kakaotechcampus.team16be.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -95,5 +96,18 @@ public class GroupMemberServiceImpl implements GroupMemberService {
         targetGroup.checkLeader(user);
 
         return groupMemberRepository.findAllByGroupAndStatus(targetGroup, PENDING);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<GroupMember> findByUser(User user) {
+        return groupMemberRepository.findAllByUser(user);
+    }
+
+    @Transactional(readOnly = true)
+    public GroupMemberInfoDto getUserInfo(User user) {
+        List<GroupMember> members = findByUser(user);
+
+        return GroupMemberInfoDto.from(user, members);
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/user/controller/UserController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/controller/UserController.java
@@ -1,11 +1,10 @@
 package com.kakaotechcampus.team16be.user.controller;
 
 import com.kakaotechcampus.team16be.common.annotation.LoginUser;
+import com.kakaotechcampus.team16be.groupMember.dto.GroupMemberInfoDto;
+import com.kakaotechcampus.team16be.groupMember.service.GroupMemberService;
 import com.kakaotechcampus.team16be.user.domain.User;
-import com.kakaotechcampus.team16be.user.dto.UpdateProfileImageRequest;
-import com.kakaotechcampus.team16be.user.dto.UserNicknameRequest;
-import com.kakaotechcampus.team16be.user.dto.UserNicknameResponse;
-import com.kakaotechcampus.team16be.user.dto.UserProfileImageResponse;
+import com.kakaotechcampus.team16be.user.dto.*;
 import com.kakaotechcampus.team16be.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final GroupMemberService groupMemberService;
 
     @Operation(summary = "프로필 이미지 등록", description = "사용자의 프로필 이미지를 최초 등록합니다.")
     @PostMapping("/profile-image")
@@ -87,6 +87,14 @@ public class UserController {
     ) {
         userService.updateNickname(user, request);
         return ResponseEntity.ok("닉네임이 변경되었습니다.");
+    }
+
+
+    @Operation(summary = "유저 정보 조회", description = "사용자의 정보를 조회합니다.")
+    @GetMapping("/info")
+    public ResponseEntity<GroupMemberInfoDto> getUserInfo(@LoginUser User user) {
+        GroupMemberInfoDto userInfo = groupMemberService.getUserInfo(user);
+        return ResponseEntity.ok(userInfo);
     }
 
 }


### PR DESCRIPTION
프론트의 요청으로 UserId, 해당 유저가 가입한 그룹, 역할, 학생인증 상태 등을 반환합니다.

그 로직상 GroupMember 컨트롤러에 구현하는게 맞는데,, api상은 뭔가 User에 더 적합한 것같고,,, 이 부분은 따로 이야기를 해봐야할것같습니다!

- close #169 