### PR TITLE
refactor: Kakao 토큰 요청 예외 세분화 및 상세 로그 추가

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/controller/AuthController.java
@@ -30,11 +30,10 @@ public class AuthController {
     @GetMapping("/kakao-login")
     public void kakaoLogin(
             @RequestParam("code") String code,
-            HttpServletRequest request,
             HttpServletResponse response
     ) throws IOException {
         // 카카오 로그인 처리 후 액세스 토큰 DTO 발급
-        KakaoLoginResponse kakaoLoginResponse = kakaoAuthService.loginWithCode(code, request);
+        KakaoLoginResponse kakaoLoginResponse = kakaoAuthService.loginWithCode(code);
 
         // 프론트로 redirect + 토큰 전달
         String redirectUrl = "http://localhost:5173/login?token="

--- a/src/main/java/com/kakaotechcampus/team16be/auth/exception/KakaoErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/exception/KakaoErrorCode.java
@@ -12,7 +12,13 @@ public enum KakaoErrorCode implements ErrorCode {
     // 500 INTERNAL_SERVER_ERROR
     TOKEN_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"AUTH-003", "카카오 토큰 요청에 실패했습니다."),
     USER_INFO_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"AUTH-004", "카카오 사용자 정보 요청에 실패했습니다."),
-    CONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH-005", "카카오 서버와의 연결에 실패했습니다.");
+    CONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH-005", "카카오 서버와의 연결에 실패했습니다."),
+    TOKEN_REQUEST_FAILED_HTTP_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH-006", "카카오 토큰 요청이 2xx 상태 코드가 아닙니다."),
+    TOKEN_REQUEST_FAILED_NULL_BODY(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH-007", "카카오 토큰 API 응답 body가 null입니다."),
+    TOKEN_REQUEST_FAILED_NO_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH-008", "카카오 토큰 API 응답에 access_token이 없습니다."),
+    TOKEN_REQUEST_FAILED_CLIENT(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH-009", "카카오 토큰 요청 중 클라이언트 에러가 발생했습니다."),
+    TOKEN_REQUEST_FAILED_SERVER(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH-010", "카카오 토큰 요청 중 서버 에러가 발생했습니다."),
+    UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH-011", "카카오 토큰 요청 중 알 수 없는 에러가 발생했습니다.");
 
     private final HttpStatus status; // HTTP 상태 코드
     private final String code;

--- a/src/main/java/com/kakaotechcampus/team16be/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/service/KakaoAuthService.java
@@ -21,7 +21,7 @@ public class KakaoAuthService {
     private final JwtProvider jwtProvider;
 
     @Transactional
-    public KakaoLoginResponse loginWithCode(String code, HttpServletRequest request) {
+    public KakaoLoginResponse loginWithCode(String code) {
         // 1. 인가 코드로 Access Token 요청
         KakaoTokenResponse kakaoTokenResponse = kakaoAuthClient.requestAccessToken(code);
         String kakaoAccessToken = kakaoTokenResponse.accessToken();


### PR DESCRIPTION
### 관련이슈
- close #172 

### 구현 내용
- requestAccessToken() 메서드에서 Kakao 토큰 요청 실패 시 발생할 수 있는 모든 경우를 세분화
  - HTTP 상태 코드 비정상: TOKEN_REQUEST_FAILED_HTTP_STATUS
  - 응답 body null: TOKEN_REQUEST_FAILED_NULL_BODY
  - access_token 누락: TOKEN_REQUEST_FAILED_NO_TOKEN
  - 클라이언트 에러: TOKEN_REQUEST_FAILED_CLIENT
  - 서버 에러: TOKEN_REQUEST_FAILED_SERVER
  - Kakao 서버 연결 실패: CONNECTION_FAILED
  - 그 외 알 수 없는 예외: UNKNOWN_ERROR
- 각 경우별로 상세 로그 출력 추가
- KakaoException에 Throwable 포함 생성자 추가로 원인 추적 가능
- 배포 환경에서 Kakao 로그인 실패 원인 파악 용이

### 기대 효과
- 배포 환경에서 Kakao 로그인 실패 시 원인을 빠르게 파악 가능
- 서버 로그를 통해 어떤 단계에서 문제가 발생했는지 확인 가능