### PR TITLE
feat: HttpClientErrorException 에러 처리 세분화

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/auth/client/KakaoAuthClient.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/client/KakaoAuthClient.java
@@ -75,7 +75,15 @@ public class KakaoAuthClient {
             return tokenResponse;
 
         } catch (HttpClientErrorException ex) {
-            log.error("HttpClientErrorException: status={} body={}", ex.getStatusCode(), ex.getResponseBodyAsString());
+            String responseBody = ex.getResponseBodyAsString();
+            log.error("Kakao Token Request Failed - Status: {}, Body: {}",
+                    ex.getStatusCode(), responseBody);
+            // 에러 메시지에서 힌트 추출
+            if (responseBody.contains("invalid_grant")) {
+                throw new KakaoException(KakaoErrorCode.INVALID_AUTHORIZATION_CODE);
+            } else if (responseBody.contains("invalid_client")) {
+                throw new KakaoException(KakaoErrorCode.INVALID_CLIENT_ID);
+            }
             throw new KakaoException(KakaoErrorCode.TOKEN_REQUEST_FAILED_CLIENT);
         } catch (HttpServerErrorException ex) {
             log.error("HttpServerErrorException: status={} body={}", ex.getStatusCode(), ex.getResponseBodyAsString());

--- a/src/main/java/com/kakaotechcampus/team16be/auth/exception/KakaoErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/exception/KakaoErrorCode.java
@@ -9,6 +9,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum KakaoErrorCode implements ErrorCode {
 
+    // 400 BAD_REQUEST - 클라이언트 입력 오류
+    INVALID_CLIENT_ID(HttpStatus.BAD_REQUEST, "AUTH-001", "유효하지 않은 카카오 클라이언트 ID입니다."),
+    INVALID_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "AUTH-002", "유효하지 않은 인가 코드입니다. 인가 코드가 만료되었거나 이미 사용되었습니다."),
+
     // 500 INTERNAL_SERVER_ERROR
     TOKEN_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"AUTH-003", "카카오 토큰 요청에 실패했습니다."),
     USER_INFO_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"AUTH-004", "카카오 사용자 정보 요청에 실패했습니다."),


### PR DESCRIPTION
### 관련이슈
- close #174 

### 구현 내용
- 기존에는 Kakao 토큰 요청 실패 시 클라이언트 에러가 발생하면 무조건 TOKEN_REQUEST_FAILED_CLIENT 예외만 던졌음
- 개선:
  - 응답 body 분석 후 세부 원인에 따라 다른 예외 처리
  - invalid_grant → INVALID_AUTHORIZATION_CODE
  - invalid_client → INVALID_CLIENT_ID
  - 그 외 클라이언트 에러 → TOKEN_REQUEST_FAILED_CLIENT
- 로그에 응답 body 출력 추가로 문제 원인 파악 용이