### PR TITLE
feat: 카카오 인가 코드 세부 에러 코드 추가 및 적용 (만료, 이미 사용됨 등)

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/auth/client/KakaoAuthClient.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/client/KakaoAuthClient.java
@@ -80,7 +80,15 @@ public class KakaoAuthClient {
                     ex.getStatusCode(), responseBody);
             // 에러 메시지에서 힌트 추출
             if (responseBody.contains("invalid_grant")) {
-                throw new KakaoException(KakaoErrorCode.INVALID_AUTHORIZATION_CODE);
+                if (responseBody.contains("code expired")) {
+                    throw new KakaoException(KakaoErrorCode.AUTH_CODE_EXPIRED);
+                } else if (responseBody.contains("already used")) {
+                    throw new KakaoException(KakaoErrorCode.AUTH_CODE_ALREADY_USED);
+                } else if (responseBody.contains("redirect_uri mismatch")) {
+                    throw new KakaoException(KakaoErrorCode.REDIRECT_URI_MISMATCH);
+                } else {
+                    throw new KakaoException(KakaoErrorCode.AUTH_CODE_INVALID);
+                }
             } else if (responseBody.contains("invalid_client")) {
                 throw new KakaoException(KakaoErrorCode.INVALID_CLIENT_ID);
             }

--- a/src/main/java/com/kakaotechcampus/team16be/auth/exception/KakaoErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/exception/KakaoErrorCode.java
@@ -12,6 +12,10 @@ public enum KakaoErrorCode implements ErrorCode {
     // 400 BAD_REQUEST - 클라이언트 입력 오류
     INVALID_CLIENT_ID(HttpStatus.BAD_REQUEST, "AUTH-001", "유효하지 않은 카카오 클라이언트 ID입니다."),
     INVALID_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "AUTH-002", "유효하지 않은 인가 코드입니다. 인가 코드가 만료되었거나 이미 사용되었습니다."),
+    AUTH_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "AUTH-012", "인가 코드가 만료되었습니다."),
+    AUTH_CODE_ALREADY_USED(HttpStatus.BAD_REQUEST, "AUTH-013", "인가 코드가 이미 사용되었습니다."),
+    AUTH_CODE_INVALID(HttpStatus.BAD_REQUEST, "AUTH-014", "유효하지 않은 인가 코드입니다."),
+    REDIRECT_URI_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH-015", "redirect_uri가 애플리케이션 설정과 일치하지 않습니다."),
 
     // 500 INTERNAL_SERVER_ERROR
     TOKEN_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"AUTH-003", "카카오 토큰 요청에 실패했습니다."),


### PR DESCRIPTION
### 관련 이슈
- close #176 

### 구현 내용
- KakaoErrorCode에 인가 코드 관련 세부 에러 추가
  - AUTH-002-01: 인가 코드가 만료된 경우
  - AUTH-002-02: 이미 사용된 인가 코드
- requestAccessToken()에서 INVALID_AUTHORIZATION_CODE 발생 시 세부 원인 구분 가능하도록 수정
- 기존 클라이언트/서버 에러 구분 유지

### 변경 이유
- 기존 INVALID_AUTHORIZATION_CODE로만 처리되어, 로컬/배포 환경에서 인가 코드 실패 원인을 정확히 파악하기 어려움
- 세부 에러 코드 추가로 디버깅 및 로깅 효율 향상

### 참고
- Kakao 토큰 요청 실패 시 로그에 세부 원인 기록 가능