### PR TITLE
fix: 카카오 인가 코드 처리 시 공백 및 URL 디코딩 적용

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/auth/client/KakaoAuthClient.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/client/KakaoAuthClient.java
@@ -16,6 +16,10 @@ import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -175,6 +179,13 @@ public class KakaoAuthClient {
 
     // Access Token 요청을 위한 HttpEntity 생성
     private HttpEntity<MultiValueMap<String, String>> buildTokenRequestEntity(String code) {
+        code = code.trim();
+        try {
+            code = URLDecoder.decode(code, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Failed to decode code", e);
+        }
+
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED); // form-data 방식
 


### PR DESCRIPTION
### 관련이슈
- close #178 

### 변경 사항
- 카카오 로그인 시 인가 코드(`code`) 전달 과정에서 발생할 수 있는
  invalid_grant 오류를 방지하기 위해 처리 로직 개선
  1. code.trim() 추가: 전달된 인가 코드의 앞뒤 공백 제거
  2. URLDecoder.decode(code, UTF-8) 추가: URL 인코딩된 문자 정상 처리

### 문제
- 배포 환경에서 인가 코드 요청 시 `AUTH_CODE_INVALID` 또는 `invalid_grant` 발생
- 로컬 환경에서는 문제가 없었음