### PR TITLE
fix: Kakao 로그인 HttpClientErrorException 처리 시 responseBody 소문자 변환 후 검사

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/auth/client/KakaoAuthClient.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/client/KakaoAuthClient.java
@@ -82,18 +82,18 @@ public class KakaoAuthClient {
             String responseBody = ex.getResponseBodyAsString();
             log.error("Kakao Token Request Failed - Status: {}, Body: {}",
                     ex.getStatusCode(), responseBody);
-            // 에러 메시지에서 힌트 추출
-            if (responseBody.contains("invalid_grant")) {
-                if (responseBody.contains("code expired")) {
+            String bodyLower = responseBody.toLowerCase(); // 소문자로 변환
+            if (bodyLower.contains("invalid_grant")) {
+                if (bodyLower.contains("code expired")) {
                     throw new KakaoException(KakaoErrorCode.AUTH_CODE_EXPIRED);
-                } else if (responseBody.contains("already used")) {
+                } else if (bodyLower.contains("already used")) {
                     throw new KakaoException(KakaoErrorCode.AUTH_CODE_ALREADY_USED);
-                } else if (responseBody.contains("redirect_uri mismatch")) {
+                } else if (bodyLower.contains("redirect uri mismatch")) {
                     throw new KakaoException(KakaoErrorCode.REDIRECT_URI_MISMATCH);
                 } else {
                     throw new KakaoException(KakaoErrorCode.AUTH_CODE_INVALID);
                 }
-            } else if (responseBody.contains("invalid_client")) {
+            } else if (bodyLower.contains("invalid_client")) {
                 throw new KakaoException(KakaoErrorCode.INVALID_CLIENT_ID);
             }
             throw new KakaoException(KakaoErrorCode.TOKEN_REQUEST_FAILED_CLIENT);


### PR DESCRIPTION
### 관련 이슈
- close #180 

### 설명
- Kakao 토큰 요청 중 `invalid_grant` 관련 에러 처리 로직 개선
- `responseBody`를 소문자로 변환 후 검사하여 대소문자 차이로 조건이 누락되는 문제 해결
- redirect URI 불일치(`redirect_uri mismatch`) 에러가 정확히 `KakaoErrorCode.REDIRECT_URI_MISMATCH`로 매핑되도록 수정

### 변경 사항
- `KakaoAuthClient`의 `HttpClientErrorException` 처리 로직에서 `responseBody.toLowerCase()` 적용
- 기존 if-else 조건 구조 유지하며, 소문자 변환으로 모든 에러 케이스 정확히 감지

### 기대 효과
- 카카오 로그인 중 redirect URI 불일치 에러가 정확하게 감지됨
- `AUTH_CODE_INVALID`로 잘못 처리되는 문제 방지