### PR TITLE
feat: EC2 배포 SSH 스크립트 deploy.yml에 환경변수 주입 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,33 @@
 name: Deploy to EC2 with GitHub Actions
-
+uses: appleboy/ssh-action@master
+with:
+  host: ${{ secrets.EC2_HOST }}
+  username: ${{ secrets.EC2_USER }}
+  key: ${{ secrets.EC2_PEM_KEY }}
+  script: |
+    set -Eeuo pipefail
+    
+    # --- 0) 환경변수 주입 ---
+    export DB_HOST=${{ secrets.DB_HOST }}
+    export DB_PORT=${{ secrets.DB_PORT }}
+    export DB_NAME=${{ secrets.DB_NAME }}
+    export DB_USERNAME=${{ secrets.DB_USERNAME }}
+    export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+    export JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
+    export KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}
+    export KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}
+    export AWS_REGION=${{ secrets.AWS_REGION }}
+    export AWS_S3_BUCKET=${{ secrets.AWS_S3_BUCKET }}
+    export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+    export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    export DEFAULT_IMG=${{ secrets.DEFAULT_IMG }}
+    
+    APP_DIR="/home/${USER}/Team16_BE"
+    JAR_NAME="${{ steps.find_jar.outputs.JAR_NAME }}"
+    APP_JAR="app.jar"
+    LOG_DIR="${APP_DIR}/logs"
+    
+    cd "${APP_DIR}" || { echo "Failed to change directory to ${APP_DIR}"; exit 1; }
 on:
   push:
     branches: [develop]


### PR DESCRIPTION
### 관련 이슈
- close #182 

### 구현 사항
- EC2에서 애플리케이션 실행 시 필요한 환경변수(DB, JWT, Kakao, AWS 등)를 SSH 스크립트에서 주입하도록 수정
- 기존 배포/실행 로직은 변경하지 않고, 환경변수 주입만 추가
- GitHub Actions Secrets를 사용하여 안전하게 값 관리

### 변경 사항
- Deploy and Run on EC2 단계 SSH 스크립트에 환경변수 `export` 추가
- 배포 시 Spring Boot가 Secrets 기반 환경변수를 참조 가능하도록 설정