### PR TITLE
feat: 로그인한 사용자의 프로필 및 그룹 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/group/repository/GroupRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/repository/GroupRepository.java
@@ -2,9 +2,19 @@ package com.kakaotechcampus.team16be.group.repository;
 
 import com.kakaotechcampus.team16be.group.domain.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface GroupRepository extends JpaRepository<Group, Long> {
     boolean existsGroupByName(String name);
+
+    @Query("SELECT gm.group.id FROM GroupMember gm WHERE gm.user.id = :userId")
+    List<String> findMemberGroupIdsByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT g.id FROM Group g WHERE g.leader.id = :userId")
+    List<String> findLeaderGroupIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/kakaotechcampus/team16be/user/controller/UserController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/controller/UserController.java
@@ -2,10 +2,7 @@ package com.kakaotechcampus.team16be.user.controller;
 
 import com.kakaotechcampus.team16be.common.annotation.LoginUser;
 import com.kakaotechcampus.team16be.user.domain.User;
-import com.kakaotechcampus.team16be.user.dto.UpdateProfileImageRequest;
-import com.kakaotechcampus.team16be.user.dto.UserNicknameRequest;
-import com.kakaotechcampus.team16be.user.dto.UserNicknameResponse;
-import com.kakaotechcampus.team16be.user.dto.UserProfileImageResponse;
+import com.kakaotechcampus.team16be.user.dto.*;
 import com.kakaotechcampus.team16be.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -87,6 +84,15 @@ public class UserController {
     ) {
         userService.updateNickname(user, request);
         return ResponseEntity.ok("닉네임이 변경되었습니다.");
+    }
+
+    @Operation(summary = "로그인한 사용자의 프로필 및 그룹 소속 정보 조회", description = "로그인한 사용자의 프로필 및 그룹 소속 정보를 반환합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<UserInfoResponse> getUserInfo(
+            @LoginUser User user
+    ) {
+        UserInfoResponse response = userService.getUserInfo(user);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/com/kakaotechcampus/team16be/user/domain/User.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/domain/User.java
@@ -73,4 +73,8 @@ public class User extends BaseEntity {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
+
+    public boolean isStudentVerified() {
+        return this.verificationStatus == VerificationStatus.VERIFIED;
+    }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/dto/UserInfoResponse.java
@@ -1,0 +1,24 @@
+package com.kakaotechcampus.team16be.user.dto;
+
+import com.kakaotechcampus.team16be.user.domain.User;
+
+import java.util.List;
+import java.util.Map;
+
+public record UserInfoResponse(
+        String id,
+        String nickname,
+        String profileImageUrl,
+        boolean isStudentVerified,
+        Map<String, List<String>> groups
+) {
+    public static UserInfoResponse of(User user, Map<String, List<String>> groups) {
+        return new UserInfoResponse(
+                user.getId().toString(),
+                user.getNickname(),
+                user.getProfileImageUrl(),
+                user.isStudentVerified(),
+                groups
+        );
+    }
+}


### PR DESCRIPTION
### 관련이슈
- close #186 

### 구현 이유
프론트측에서 로그인한 사용자의 프로필 및 그룹 소속 정보를 반환하는 API가 필요하다고 함

### 구현 사항
프론트엔드에서 사용자 프로필(닉네임, 이미지, 학생 인증 여부 등)과 그룹 소속 정보를 한 번에 조회할 수 있도록 GET /api/v1/users/me API를 추가했습니다.

### 요구사항 정리
- 엔드포인트: GET /api/v1/users/me
- 반환 JSON 예시:
```
{
  "id": "user123",
  "nickname": "gemini",
  "profileImageUrl": "https://path/to/avatar.png",
  "isStudentVerified": true,
  "groups": {
    "leaderOf": ["1", "2"],
    "memberOf": ["1", "4", "7", "11"]
  }
}
```
- 현재 인증된 사용자 기준으로 정보 반환

### 테스트 결과
<img width="890" height="727" alt="image" src="https://github.com/user-attachments/assets/46111ceb-671b-46eb-a5e0-e7f454a8493f" />
