### PR TITLE
feat: 그룹 상세 조회 API 반환값에 createdAt, capacity 필드 추가

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/group/controller/GroupController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/controller/GroupController.java
@@ -43,7 +43,8 @@ public class GroupController {
     @Operation(summary = "모임 상세 조회", description = "특정 모임의 상세 정보를 조회합니다.")
     @GetMapping("/{groupId}")
     public ResponseEntity<ResponseSingleGroupDto> getGroup(@PathVariable("groupId") Long groupId) {
-        return ResponseEntity.ok(groupFacade.getGroup(groupId));
+        ResponseSingleGroupDto responseSingleGroupDto = groupFacade.getGroup(groupId);
+        return ResponseEntity.ok(responseSingleGroupDto);
     }
 
     @Operation(summary = "모임 삭제", description = "특정 모임을 삭제합니다.")

--- a/src/main/java/com/kakaotechcampus/team16be/group/dto/ResponseSingleGroupDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/dto/ResponseSingleGroupDto.java
@@ -2,12 +2,16 @@ package com.kakaotechcampus.team16be.group.dto;
 
 import com.kakaotechcampus.team16be.group.domain.Group;
 
+import java.time.LocalDateTime;
+
 public record ResponseSingleGroupDto(
         Long groupId,
         String name,
         String intro,
         String safetyTag,
-        String coverImageUrl
+        String coverImageUrl,
+        LocalDateTime createdAt,
+        int capacity
 ) {
 
     public static ResponseSingleGroupDto from(Group group, String coverImageUrl) {
@@ -16,6 +20,9 @@ public record ResponseSingleGroupDto(
                 group.getName(),
                 group.getIntro(),
                 group.getSafetyTag().name(),
-                coverImageUrl);
+                coverImageUrl,
+                group.getCreatedAt(),
+                group.getCapacity()
+        );
     }
 }


### PR DESCRIPTION
### 관련 이슈
- close #188 

### 설명
프론트엔드 요청에 따라 모임 상세 조회 API 응답에 createdAt(생성일)과 capacity(정원) 필드를 추가했습니다.
Group 엔티티에 해당 데이터가 이미 존재하므로, DTO(ResponseSingleGroupDto) 확장만으로 처리했습니다.

### 변경 사항
- ResponseSingleGroupDto
  - LocalDateTime createdAt 필드 추가
  - int capacity 필드 추가
- from() 메서드 내 group.getCreatedAt(), group.getCapacity() 반환 추가
- 서비스(getGroup) 로직 변경 없음 (DTO 내부 처리)