### PR TITLE
fix: /api/users/me 학생 인증 상태 enum으로 반환하도록 변경

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/dto/UserInfoResponse.java
@@ -1,6 +1,7 @@
 package com.kakaotechcampus.team16be.user.dto;
 
 import com.kakaotechcampus.team16be.user.domain.User;
+import com.kakaotechcampus.team16be.user.domain.VerificationStatus;
 
 import java.util.List;
 import java.util.Map;
@@ -9,7 +10,7 @@ public record UserInfoResponse(
         String id,
         String nickname,
         String profileImageUrl,
-        boolean isStudentVerified,
+        VerificationStatus isStudentVerified,
         Map<String, List<String>> groups
 ) {
     public static UserInfoResponse of(User user, Map<String, List<String>> groups) {
@@ -17,7 +18,7 @@ public record UserInfoResponse(
                 user.getId().toString(),
                 user.getNickname(),
                 user.getProfileImageUrl(),
-                user.isStudentVerified(),
+                user.getVerificationStatus(),
                 groups
         );
     }


### PR DESCRIPTION
### 설명
프론트엔드 요청에 따라 `/api/users/me` API에서 `isStudentVerified`를 boolean 대신 상태(`UNVERIFIED`, `PENDING`, `VERIFIED`)로 반환하도록 변경합니다.

### 이전 관련 이슈
- #186 

### 현재 이슈
- close #192 

### 변경 내용
- `UserInfoResponse` DTO 수정
  - 기존: `boolean isStudentVerified`
  - 변경: `VerificationStatus isStudentVerified` (`UNVERIFIED`, `PENDING`, `VERIFIED`)
- 서비스 레이어에서 로그인한 사용자 정보 조회 시 `VerificationStatus` 매핑
- 기존 그룹 정보(`leaderOf`, `memberOf`) 조회 로직 유지

### 요구 사항
- **엔드포인트:** `GET /api/v1/users/me`
- **반환 JSON 예시:**
```json
{
  "id": "user123",
  "nickname": "gemini",
  "profileImageUrl": "https://path/to/avatar.png",
  "isStudentVerified": "VERIFIED",
  "groups": {
    "leaderOf": ["1", "2"],
    "memberOf": ["1", "4", "7", "11"]
  }
}