### PR TITLE
refactor: AttendRepository null 반환 메서드 Optional 처리 및 서비스 null handling 개선

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/attend/exception/AttendErrorCode.java
+++ b/src/main/java/com/kakaotechcampus/team16be/attend/exception/AttendErrorCode.java
@@ -1,0 +1,17 @@
+package com.kakaotechcampus.team16be.attend.exception;
+
+import com.kakaotechcampus.team16be.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AttendErrorCode implements ErrorCode {
+    // 404 Not Found
+    ATTEND_NOT_FOUND(HttpStatus.NOT_FOUND, "ATTEND-001", "해당 출석 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/kakaotechcampus/team16be/attend/exception/AttendException.java
+++ b/src/main/java/com/kakaotechcampus/team16be/attend/exception/AttendException.java
@@ -1,0 +1,29 @@
+package com.kakaotechcampus.team16be.attend.exception;
+
+import com.kakaotechcampus.team16be.common.exception.BaseException;
+import lombok.Getter;
+
+@Getter
+public class AttendException extends BaseException {
+
+    private final AttendErrorCode errorCode;
+
+    public AttendException(AttendErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+
+    @Override
+    public String getCode() {
+        return errorCode.getCode();
+    }
+
+    @Override
+    public int getStatus() {
+        return errorCode.getStatus().value();
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/attend/repository/AttendRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/attend/repository/AttendRepository.java
@@ -8,12 +8,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface AttendRepository extends JpaRepository<Attend, Long> {
 
     List<Attend> findAllByPlan(Plan plan);
 
-    Attend findByPlanAndGroupMember(Plan plan, GroupMember groupMember);
+    Optional<Attend> findByPlanAndGroupMember(Plan plan, GroupMember groupMember);
 
     List<Attend> findAllByPlanAndGroupMemberNotIn(Plan plan, Collection<GroupMember> groupMembers);
 

--- a/src/main/java/com/kakaotechcampus/team16be/attend/repository/AttendRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/attend/repository/AttendRepository.java
@@ -13,8 +13,6 @@ public interface AttendRepository extends JpaRepository<Attend, Long> {
 
     List<Attend> findAllByPlan(Plan plan);
 
-    Attend findByPlan(Plan plan);
-
     Attend findByPlanAndGroupMember(Plan plan, GroupMember groupMember);
 
     List<Attend> findAllByPlanAndGroupMemberNotIn(Plan plan, Collection<GroupMember> groupMembers);

--- a/src/main/java/com/kakaotechcampus/team16be/attend/service/AttendServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/attend/service/AttendServiceImpl.java
@@ -3,6 +3,8 @@ package com.kakaotechcampus.team16be.attend.service;
 import com.kakaotechcampus.team16be.attend.domain.AttendStatus;
 import com.kakaotechcampus.team16be.attend.dto.RequestAttendDto;
 import com.kakaotechcampus.team16be.attend.domain.Attend;
+import com.kakaotechcampus.team16be.attend.exception.AttendErrorCode;
+import com.kakaotechcampus.team16be.attend.exception.AttendException;
 import com.kakaotechcampus.team16be.attend.repository.AttendRepository;
 import com.kakaotechcampus.team16be.group.domain.Group;
 import com.kakaotechcampus.team16be.group.service.GroupService;
@@ -11,15 +13,10 @@ import com.kakaotechcampus.team16be.groupMember.service.GroupMemberService;
 import com.kakaotechcampus.team16be.plan.domain.Plan;
 import com.kakaotechcampus.team16be.plan.service.PlanService;
 import com.kakaotechcampus.team16be.user.domain.User;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 
 @Service
 @RequiredArgsConstructor
@@ -65,8 +62,9 @@ public class AttendServiceImpl implements AttendService{
         Group targetGroup = groupService.findGroupById(groupId);
         GroupMember groupMember = groupMemberService.findByGroupAndUser(targetGroup, user);
         Plan plan = planService.findByGroupIdAndPlanId(groupId, planId);
-
-        return attendRepository.findByPlanAndGroupMember(plan, groupMember);
+        Attend attend = attendRepository.findByPlanAndGroupMember(plan, groupMember)
+                .orElseThrow(() -> new AttendException(AttendErrorCode.ATTEND_NOT_FOUND));
+        return attend;
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
### 문제
현재 AttendRepository의 단건 조회 메서드(findByPlan, findByPlanAndGroupMember 등)는
조건에 맞는 데이터가 없으면 null을 반환합니다.
이로 인해 서비스 레이어에서 별도의 null 처리 없이 컨트롤러로 전달될 경우 NPE 발생 가능성이 있습니다.

### 개선 사항
1. Repository 단건 조회 메서드 반환 타입을 Optional로 변경
   - Attend findByPlan(Plan plan) → Optional<Attend> findByPlan(Plan plan) → 사용하지 않는 메서드이므로 제거하였습니다.
   - Attend findByPlanAndGroupMember(Plan plan, GroupMember groupMember) → Optional<Attend> findByPlanAndGroupMember(Plan plan, GroupMember groupMember)

2. 서비스 레이어에서 Optional 처리
   - Optional.orElseThrow()를 사용하여 명시적으로 예외 처리
   - 필요 시 기본값 제공 가능

3. AttendException과 AttendErrorCode 추가
   - 조회 실패 시 ATTEND_NOT_FOUND 예외 발생

### 기대 효과
- NPE 발생 가능성 제거
- null 처리 과정 명시적 적용으로 코드 안정성 향상
- 서비스/컨트롤러 계층에서 안전하게 데이터 처리 가능