### PR TITLE
chore: Hibernate 전역 Batch Fetch Size 50으로 설정하여 N+1 문제 완화

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,7 @@ spring.datasource.password=${DB_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
+spring.jpa.properties.hibernate.default_batch_fetch_size=50
 
 # jwt
 jwt.secret=${JWT_SECRET_KEY}


### PR DESCRIPTION
### 관련 이슈
- 1. close #145 
- 2. close #171 

### 문제 상황
1. `GroupMemberDto.from()` 메서드에서 `member.getGroup().getName()`과 `member.getUser().getNickname()` 호출 시 N+1 쿼리 발생
   - GroupMember 엔티티에서 Group과 User가 `@ManyToOne(fetch = LAZY)`로 설정되어 있어,  
     Repository에서 멤버 리스트 조회 후 DTO 변환 시점에 각각 별도의 쿼리 발생
   - 예시: 멤버 10명 기준 → 총 1 + (10*2) = 21번 쿼리 발생
   - 작은 데이터에서는 문제가 크지 않지만, 멤버 수가 많아지면 DB 부하 및 성능 저하 발생

2. `CommentFacadeService.getCommentsByPostId` 메서드에서 Post와 연관된 Comment 조회 시 N+1 쿼리 발생 가능
   - Post 1개 조회 → 1쿼리
   - 해당 Post의 Comment 10개 조회 → 각 Comment마다 추가 쿼리 발생  
     → 총 11번 이상의 쿼리 발생 가능
   - JPA Lazy Loading으로 인해 성능 저하와 서버 부하 발생 가능

### 해결 방법
- `spring.jpa.properties.hibernate.default_batch_fetch_size=50` 전역 설정 적용
  - Hibernate가 LAZY 관계를 **한 번에 50개씩 묶어서 조회**하도록 설정
- 엔티티 단위 `@BatchSize` 제거하여 전역 설정으로 통일
- N+1 문제가 발생할 수 있는 GroupMember, Comment 등 모든 LAZY 관계에서 Batch Fetch 적용

### 선택 이유
- 전역 Batch Fetch Size 설정만으로 대부분의 N+1 문제 해결 가능
- Comment, GroupMember, User 등 LAZY 관계가 많은 엔티티에서 쿼리 수 감소
- 별도 Repository 수정이나 JPQL JOIN FETCH, EntityGraph 적용 없이 간단히 최적화 가능
- 관리가 단순하며, 메모리 부담이 크지 않은 범위에서 성능 향상 기대 가능
