### PR TITLE
fix: 사용자 마이페이지 조회 API들을 userId 기반 조회로 변경

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakaotechcampus/team16be/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -23,9 +24,10 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ErrorResponseDto(
-                        "예상치 못한 서버 오류가 발생했습니다.",
+                        e.getMessage(),
                         "UNEXPECTED_ERROR",
                         HttpStatus.INTERNAL_SERVER_ERROR.value()
                 ));
     }
+
 }

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/repository/GroupMemberRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/repository/GroupMemberRepository.java
@@ -21,10 +21,10 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember,Long> {
     List<GroupMember> findAllByGroupAndStatus(Group group, GroupMemberStatus status);
 
     @Query("SELECT gm FROM GroupMember gm " +
-            "WHERE gm.user = :user AND gm.status IN :statuses " +
+            "WHERE gm.user.id = :userId AND gm.status IN :statuses " +
             "ORDER BY gm.joinAt DESC")
-    List<GroupMember> findAllByUserAndStatusIn(
-            @Param("user") User user,
+    List<GroupMember> findAllByUserIdAndStatusIn(
+            @Param("userId") Long userId,
             @Param("statuses") List<GroupMemberStatus> statuses
     );
 }

--- a/src/main/java/com/kakaotechcampus/team16be/user/controller/UserController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/controller/UserController.java
@@ -88,21 +88,21 @@ public class UserController {
         return ResponseEntity.ok("닉네임이 변경되었습니다.");
     }
 
-    @Operation(summary = "로그인한 사용자의 프로필 및 그룹 소속 정보 조회", description = "로그인한 사용자의 프로필 및 그룹 소속 정보를 반환합니다.")
-    @GetMapping("/me")
+    @Operation(summary = "사용자의 프로필 및 그룹 소속 정보 조회", description = "사용자의 프로필 및 그룹 소속 정보를 반환합니다.")
+    @GetMapping("/{userId}/me")
     public ResponseEntity<UserInfoResponse> getUserInfo(
-            @LoginUser User user
+            @PathVariable Long userId
     ) {
-        UserInfoResponse response = userService.getUserInfo(user);
+        UserInfoResponse response = userService.getUserInfo(userId);
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "사용자의 그룹 활동 내역 조회 (나의활동이력)", description = "로그인한 사용자의 그룹 참여 및 탈퇴 이력을 반환합니다.")
-    @GetMapping("/groups/history")
+    @Operation(summary = "사용자의 그룹 활동 내역 조회 (나의활동이력)", description = "사용자의 그룹 참여 및 탈퇴 이력을 반환합니다.")
+    @GetMapping("/{userId}/groups/history")
     public ResponseEntity<List<UserGroupHistoryResponse>> getUserGroupHistory(
-            @LoginUser User user
+            @PathVariable Long userId
     ) {
-        List<UserGroupHistoryResponse> response = userService.getUserGroupHistory(user);
+        List<UserGroupHistoryResponse> response = userService.getUserGroupHistory(userId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
@@ -122,9 +122,11 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public UserInfoResponse getUserInfo(User user) {
-        List<String> leaderGroupIds = groupRepository.findLeaderGroupIdsByUserId(user.getId());
-        List<String> memberGroupIds = groupRepository.findMemberGroupIdsByUserId(user.getId());
+    public UserInfoResponse getUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        List<String> leaderGroupIds = groupRepository.findLeaderGroupIdsByUserId(userId);
+        List<String> memberGroupIds = groupRepository.findMemberGroupIdsByUserId(userId);
 
         Map<String, List<String>> groups = Map.of(
                 "leaderOf", leaderGroupIds,
@@ -134,9 +136,9 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public List<UserGroupHistoryResponse> getUserGroupHistory(User user) {
-        List<GroupMember> memberships = groupMemberRepository.findAllByUserAndStatusIn(
-                user,
+    public List<UserGroupHistoryResponse> getUserGroupHistory(Long userId) {
+        List<GroupMember> memberships = groupMemberRepository.findAllByUserIdAndStatusIn(
+                userId,
                 List.of(GroupMemberStatus.ACTIVE, GroupMemberStatus.LEFT, GroupMemberStatus.BANNED)
         );
 


### PR DESCRIPTION
### 관련 이슈
- close #197 

### 📝 변경 내용
- 기존 /api/users/me, /api/users/history 엔드포인트를 PathVariable로 userId를 받는 구조로 변경하였습니다.
- 이제 어떤 사용자든 /api/users/{userId}, /api/users/{userId}/history로 조회 가능합니다.

### 💬 변경 이유
- 다른 사람의 마이페이지나 히스토리를 조회해야할 필요가 있기 때문입니다. 기존엔 로그인한 사용자 본인꺼만 조회가 가능했습니다.
- 별도의 /api/users/{userId} API를 새로 만드는 대신, 기존 /me 구조를 확장하는 편이 유지보수성 측면에서 더 효율적입니다.

### 추가 작업 사항
- GlobalExceptionHandler에서 발생한 모든 예외 메시지를 직접 반환하도록 수정하였습니다.  
- 기존에는 잘못된 API 경로로 요청할 경우 "예상치 못한 서버 오류"만 표시되어 원인 파악이 어려웠습니다.  
- 따라서 NoHandlerFoundException과 같은 예상치 못한 오류의 경우에도 실제 예외 메시지를 클라이언트에 직접 반환하도록 개선하였습니다.

### 변경 이후 예상치 못한 서버 오류 발생시 에러 처리 결과 (추가작업사항)
- url 잘못 입력했을 경우
<img width="447" height="179" alt="image" src="https://github.com/user-attachments/assets/c2a93985-77d0-4837-a7e3-5c6e4e9d3661" />

- 메소드 잘못 입력했을 경우
<img width="511" height="191" alt="image" src="https://github.com/user-attachments/assets/c63bc2db-f13a-4a60-815a-e90a003a68a6" />
