### PR TITLE
feat: 유저 그룹 이력 조회 API에 groupId 필드 추가로 반환

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/user/dto/UserGroupHistoryResponse.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/dto/UserGroupHistoryResponse.java
@@ -7,6 +7,7 @@ import com.kakaotechcampus.team16be.groupMember.domain.GroupMemberStatus;
 import java.time.format.DateTimeFormatter;
 
 public record UserGroupHistoryResponse(
+        Long groupId,
         String name,
         GroupMemberStatus groupMemberStatus,
         SafetyTag safetyTag,
@@ -20,6 +21,7 @@ public record UserGroupHistoryResponse(
         String leftAt = member.getLeftAt() != null ? member.getLeftAt().format(FORMATTER) : null;
 
         return new UserGroupHistoryResponse(
+                member.getGroup().getId(),
                 member.getGroup().getName(),
                 member.getStatus(),
                 member.getGroup().getSafetyTag(),


### PR DESCRIPTION
### 관련 이슈
- close #199 

### 변경 내용
- UserGroupHistoryResponse DTO에 groupId 필드 추가
- from(GroupMember) 메서드에서 member.getGroup().getId() 반환하도록 수정

### 변경 이유
- 프론트엔드에서 그룹 상세 페이지 이동 시 groupId가 필요
- 기존 응답에 groupId가 없어 추가 데이터 요청이 필요했음

### 기대 효과
- 프론트엔드에서 유저 그룹 이력 조회 및 상세 페이지 이동 시 groupId 활용 가능