### PR TITLE
feat: getGroupMember User profileImageUrl 반환

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/GroupMemberDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/GroupMemberDto.java
@@ -9,7 +9,8 @@ public record GroupMemberDto(
         Long id,
         String groupName,
         String nickname,
-        GroupRole groupRole
+        GroupRole groupRole,
+        String profileImageUrl
 ) {
 
     public static List<GroupMemberDto> from(List<GroupMember> members) {
@@ -18,7 +19,8 @@ public record GroupMemberDto(
                         member.getId(),
                         member.getGroup().getName(),
                         member.getUser().getNickname(),
-                        member.getRole()
+                        member.getRole(),
+                        member.getUser().getProfileImageUrl()
                 ))
                 .toList();
     }


### PR DESCRIPTION
프론트측의 요청으로 사용자의 프로필 이미지도 같이 반환하도록 추가하였습니다.

<img width="839" height="322" alt="image" src="https://github.com/user-attachments/assets/0033fa24-7798-4b1b-be76-dc9449297bdc" />

- close #201 