### PR TITLE
fix: 가입신청 User 이미지 공개 URL 반환

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/controller/GroupMemberController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/controller/GroupMemberController.java
@@ -80,9 +80,9 @@ public class GroupMemberController {
     public ResponseEntity<List<SignResponseDto>> getAllJoinRequest(
             @LoginUser User user, @PathVariable Long groupId
     ) {
-        List<GroupMember> members = groupMemberService.findByGroupAndPendingUser(user, groupId);
+        List<SignResponseDto> members = groupMemberService.findByGroupAndPendingUser(user, groupId);
 
-        return ResponseEntity.ok(SignResponseDto.from(members));
+        return ResponseEntity.ok(members);
     }
 
     @Operation(summary = "그룹별 멤버", description = "해당 그룹에 가입한 멤버 반환")

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/SignResponseDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/SignResponseDto.java
@@ -1,18 +1,19 @@
 package com.kakaotechcampus.team16be.groupMember.dto;
 
 import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
-
 import java.util.List;
 
 public record SignResponseDto(
         Long userId,
-        String intro
+        String intro,
+        String profileImageUrl
 ) {
     public static List<SignResponseDto> from(List<GroupMember> members) {
         return members.stream()
                 .map(m -> new SignResponseDto(
                         m.getUser().getId(),
-                        m.getIntro()
+                        m.getIntro(),
+                        m.getUser().getProfileImageUrl()
                 ))
                 .toList();
     }

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberService.java
@@ -2,6 +2,7 @@ package com.kakaotechcampus.team16be.groupMember.service;
 
 import com.kakaotechcampus.team16be.group.domain.Group;
 import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
+import com.kakaotechcampus.team16be.groupMember.dto.SignResponseDto;
 import com.kakaotechcampus.team16be.user.domain.User;
 
 import java.util.List;
@@ -22,7 +23,7 @@ public interface GroupMemberService {
 
     void validateGroupMember(User user, Long groupId);
 
-    List<GroupMember> findByGroupAndPendingUser(User user, Long groupId);
+    List<SignResponseDto> findByGroupAndPendingUser(User user, Long groupId);
 
     List<GroupMember> getGroupMember(User user, Long groupId);
 }


### PR DESCRIPTION
가입신청 페이지에서 이미지 fileName 그대로 반환했던 로직을 s3서비스를 통해 공개 URL로 반환하는 로직으로 수정했습니다.

<img width="746" height="211" alt="image" src="https://github.com/user-attachments/assets/760c7f9d-772f-4633-b7f7-12f9ac771de9" />

- close #208 
