### PR TITLE
fix: 그룹 생성 시 리더가 GroupMember에 등록되지 않는 문제 수정

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
@@ -7,6 +7,8 @@ import com.kakaotechcampus.team16be.group.dto.UpdateGroupDto;
 import com.kakaotechcampus.team16be.group.exception.GroupErrorCode;
 import com.kakaotechcampus.team16be.group.exception.GroupException;
 import com.kakaotechcampus.team16be.group.repository.GroupRepository;
+import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
+import com.kakaotechcampus.team16be.groupMember.repository.GroupMemberRepository;
 import com.kakaotechcampus.team16be.user.domain.User;
 import com.kakaotechcampus.team16be.user.exception.UserErrorCode;
 import com.kakaotechcampus.team16be.user.exception.UserException;
@@ -26,6 +28,7 @@ public class GroupServiceImpl implements GroupService {
     private final GroupRepository groupRepository;
     private final UserRepository userRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final GroupMemberRepository groupMemberRepository;
 
 
     @Transactional
@@ -35,15 +38,20 @@ public class GroupServiceImpl implements GroupService {
         String groupIntro = createGroupDto.intro();
         Integer groupCapacity = createGroupDto.capacity();
 
-        User leader = userRepository.findById(user.getId()).orElseThrow(()->new UserException(UserErrorCode.USER_NOT_FOUND));
+        User leader = userRepository.findById(user.getId())
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
-        Group createdGroup = Group.createGroup(leader, groupName, groupIntro, groupCapacity);
-
-        if (existGroupName(createdGroup.getName())) {
+        if (existGroupName(groupName)) {
             throw new GroupException(GroupErrorCode.GROUP_NAME_DUPLICATE);
         }
 
-        return groupRepository.save(createdGroup);
+        Group createdGroup = Group.createGroup(leader, groupName, groupIntro, groupCapacity);
+        groupRepository.save(createdGroup);
+
+        GroupMember leaderMember = GroupMember.acceptJoin(createdGroup, leader);
+        groupMemberRepository.save(leaderMember);
+
+        return createdGroup;
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
### 관련 이슈 
- close #212 

### 변경 내용
- 그룹 생성 시 리더를 `GroupMember`로 함께 등록하도록 로직 수정  
- 그룹장이 그룹 멤버로 인식되지 않아 게시글 생성 시 그룹 미가입자로 처리되던 문제 해결

### 변경 이유
기존에는 그룹 생성 시 리더가 `GroupMember` 엔티티에 포함되지 않아  
게시글 작성 시 그룹 멤버 검증 로직에서 404 Not Found가 발생했음.  
이를 수정하여 그룹장이 정상적으로 게시글을 생성할 수 있도록 함.

### 추가 필요 작업
기존의 리더들은 전부 GroupMember 엔티티에 추가가 되지 않았을 것이므로 일일이 추가하는 작업이 필요할 예정