### PR TITLE
fix: 그룹 생성 시 리더 멤버 역할(LEADER)로 저장하도록 수정

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
@@ -48,7 +48,7 @@ public class GroupServiceImpl implements GroupService {
         Group createdGroup = Group.createGroup(leader, groupName, groupIntro, groupCapacity);
         groupRepository.save(createdGroup);
 
-        GroupMember leaderMember = GroupMember.acceptJoin(createdGroup, leader);
+        GroupMember leaderMember = GroupMember.create(createdGroup, leader);
         groupMemberRepository.save(leaderMember);
 
         return createdGroup;


### PR DESCRIPTION
### 관련 이슈 
- close #212 

### 변경 내용
- 기존에는 그룹장 생성 시 acceptJoin() 사용으로 MEMBER 역할로 저장됨
- GroupMember.create()를 사용해 그룹장 멤버를 LEADER 역할로 생성하도록 변경