### PR TITLE
fix: getGroupMember ACTIVE 멤버만 반환하도록 수정

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
@@ -124,7 +124,7 @@ public class GroupMemberServiceImpl implements GroupMemberService {
     public List<GroupMemberDto> getGroupMember(User user, Long groupId) {
         validateGroupMember(user, groupId);
         Group targetGroup = groupService.findGroupById(groupId);
-        List<GroupMember> members = groupMemberRepository.findAllByGroup(targetGroup);
+        List<GroupMember> members = groupMemberRepository.findAllByGroupAndStatus(targetGroup,ACTIVE);
 
         return members.stream()
                 .map(member -> {


### PR DESCRIPTION
기존 GroupMember의 getGroupMember 메서드가 모든 멤버들 ( PENDING, BANNED, CANCELED) 등이 포함되어 반환되어 수정하였습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Group member lists now display only active members, filtering out inactive accounts from query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->