### PR TITLE
refactor: 민감 정보 로그 제거 및 카카오 인증 로깅 개선

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/auth/client/KakaoAuthClient.java
+++ b/src/main/java/com/kakaotechcampus/team16be/auth/client/KakaoAuthClient.java
@@ -74,7 +74,7 @@ public class KakaoAuthClient {
 
         } catch (HttpClientErrorException ex) {
             String responseBody = ex.getResponseBodyAsString();
-            log.warn("Kakao Token Request Failed - Status: {} (response body masked)", ex.getStatusCode());
+            log.warn("Kakao Token Request Failed - Status: {}", ex.getStatusCode());
             String bodyLower = responseBody.toLowerCase(); // 소문자로 변환
             if (bodyLower.contains("invalid_grant")) {
                 if (bodyLower.contains("code expired")) {


### PR DESCRIPTION
### 관련이슈
- close #238 

### 변경사항
- Kakao Token API 요청/응답 중 code, client_id 등 credential 관련 로그 제거
- 예외 발생 시 response body 원문을 제거하여 민감정보 노출 방지
- HttpClientErrorException 로그 레벨을 ERROR → WARN으로 조정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized authentication logging to reduce verbosity while maintaining error reporting clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->