### PR TITLE
bugfix: ChatRoom 엔티티의 id 타입(UUID 기반 String)과 ChatRoomRepository&service의 제네릭 타입(Long)이 불일치했던 문제 수정

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/controller/ChatRoomController.java
@@ -35,14 +35,14 @@ public class ChatRoomController {
     }
 
     @PutMapping("/{groupId}/chat/{chatRoomId}")
-    public ResponseEntity<ResponseChatRoomDto> updateChatRoom(@LoginUser User user, @PathVariable Long groupId, @RequestBody UpdateChatRoomDto updateChatRoomDto, @PathVariable Long chatRoomId) {
+    public ResponseEntity<ResponseChatRoomDto> updateChatRoom(@LoginUser User user, @PathVariable Long groupId, @RequestBody UpdateChatRoomDto updateChatRoomDto, @PathVariable String chatRoomId) {
         ChatRoom chatRoom = chatRoomService.updateChatRoom(user, groupId, updateChatRoomDto, chatRoomId);
 
         return ResponseEntity.ok(ResponseChatRoomDto.from(chatRoom));
     }
 
     @DeleteMapping("/{groupId}/chat/{chatRoomId}")
-    public ResponseEntity<Void> deleteChatRoom(@LoginUser User user, @PathVariable Long groupId, @PathVariable Long chatRoomId) {
+    public ResponseEntity<Void> deleteChatRoom(@LoginUser User user, @PathVariable Long groupId, @PathVariable String chatRoomId) {
         chatRoomService.deleteChatRoom(user, groupId, chatRoomId);
 
         return ResponseEntity.ok().build();

--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/repository/ChatRoomRepository.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ChatRoomRepository extends CrudRepository<ChatRoom, Long> {
+public interface ChatRoomRepository extends CrudRepository<ChatRoom, String> {
     List<ChatRoom> findChatRoomsByGroup(Group group);
 
 }

--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/service/ChatRoomService.java
@@ -12,8 +12,8 @@ public interface ChatRoomService {
 
     ChatRoom createChatRoom(User user, Long groupId, CreateChatRoomDto createChatRoomDto);
 
-    ChatRoom updateChatRoom(User user, Long groupId, UpdateChatRoomDto updateChatRoomDto, Long chatRoomId);
+    ChatRoom updateChatRoom(User user, Long groupId, UpdateChatRoomDto updateChatRoomDto, String chatRoomId);
 
-    void deleteChatRoom(User user, Long groupId, Long chatRoomId);
+    void deleteChatRoom(User user, Long groupId, String chatRoomId);
 
 }

--- a/src/main/java/com/kakaotechcampus/team16be/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/chatroom/service/ChatRoomServiceImpl.java
@@ -49,7 +49,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
     @Transactional
     @Override
-    public ChatRoom updateChatRoom(User user, Long groupId, UpdateChatRoomDto updateChatRoomDto, Long chatRoomId) {
+    public ChatRoom updateChatRoom(User user, Long groupId, UpdateChatRoomDto updateChatRoomDto, String chatRoomId) {
         Group targetGroup  = groupService.findGroupById(groupId);
         targetGroup.checkLeader(user);
 
@@ -61,12 +61,12 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         return chatRoomRepository.save(updatedRoom);
     }
 
-    public ChatRoom findChatRoomById(long chatRoomId) {
+    public ChatRoom findChatRoomById(String chatRoomId) {
         return chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
     }
 
-    public void deleteChatRoom(User user, Long groupId, Long chatRoomId) {
+    public void deleteChatRoom(User user, Long groupId, String chatRoomId) {
         Group targetGroup  = groupService.findGroupById(groupId);
         targetGroup.checkLeader(user);
 


### PR DESCRIPTION
### 관련 이슈
- close #256 

### 변경 사항
- `ChatRoom` 엔티티의 `id` 타입(`UUID` 기반 `String`)과 `ChatRoomRepository`의 제네릭 타입(`Long`)이 불일치했던 문제 수정  
- `CrudRepository<ChatRoom, Long>` → `CrudRepository<ChatRoom, String>` 으로 변경  
- 관련 서비스 계층(`ChatRoomService`, `ChatRoomServiceImpl`)의 `chatRoomId` 파라미터 타입을 `Long` → `String` 으로 통일  
- `findChatRoomById()`, `updateChatRoom()`, `deleteChatRoom()` 등 모든 메서드 시그니처 일관성 확보  

### 이유 (왜 String(UUID) 선택했는가)
1. **분산·확장성**: 채팅 시스템은 추후 여러 서버(WebSocket 등)로 분산될 가능성이 높음. UUID는 애플리케이션 레벨에서 고유 ID 생성이 가능해 분산 환경에서 충돌 위험이 거의 없음.  
2. **보안성**: 순차적인 Long ID는 예측 가능해 외부에 노출될 경우 리소스 스캔/무단 접근 위험이 있다. UUID는 추측이 어려워 보안면에서 유리함.  
3. **생성 시점 유연성**: DB insert 이전에도 ID를 생성해서 사용할 수 있어, 메시지 큐·캐시·비동기 작업 등에서 편리함.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced chat room identification system to support improved data handling and better platform scalability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->