### PR TITLE
fix : 그룹 생성 시, 이미지 업로드 오류 수정

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/aws/service/S3UploadPresignedUrlService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/service/S3UploadPresignedUrlService.java
@@ -131,6 +131,7 @@ public class S3UploadPresignedUrlService {
         targetGroup.checkLeader(user);
 
         String postUUID = UUID.randomUUID().toString();
+        System.out.println(postUUID);
         String valueFileExtension = fileExtension.getUploadExtension();
         String valueType = String.valueOf(ImageUploadType.POST);
         String fileName = createPostFileName(groupId, postUUID, valueFileExtension, valueType);

--- a/src/main/java/com/kakaotechcampus/team16be/group/domain/Group.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/domain/Group.java
@@ -1,5 +1,6 @@
 package com.kakaotechcampus.team16be.group.domain;
 
+import ch.qos.logback.core.util.StringUtil;
 import com.kakaotechcampus.team16be.common.BaseEntity;
 import com.kakaotechcampus.team16be.group.exception.GroupErrorCode;
 import com.kakaotechcampus.team16be.group.exception.GroupException;
@@ -66,21 +67,25 @@ public class Group extends BaseEntity {
     }
 
     @Builder
-    public Group(User user, String name, String intro, Integer capacity) {
+    public Group(User user, String name, String intro, Integer capacity,String fileName) {
         this.leader = user;
         this.name = name;
         this.intro = intro;
         this.capacity = capacity;
-        this.coverImageUrl = "";
+        if (StringUtil.isNullOrEmpty(fileName)) {
+            this.coverImageUrl = "";
+        }else
+            this.coverImageUrl = fileName;
         this.score = 80.0;
     }
 
-    public static Group createGroup(User user, String name, String intro, Integer capacity) {
+    public static Group createGroup(User user, String name, String intro, Integer capacity, String fileName) {
         return Group.builder().
                 user(user).
                 name(name).
                 intro(intro).
                 capacity(capacity).
+                fileName(fileName).
                 build();
     }
 

--- a/src/main/java/com/kakaotechcampus/team16be/group/dto/CreateGroupDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/dto/CreateGroupDto.java
@@ -15,7 +15,9 @@ public record CreateGroupDto(
 
         @NotNull
         @Min(value = 1, message = "모임 최소 인원 수는 1명입니다.")
-        Integer capacity
+        Integer capacity,
+
+        String fileName
 ) {
 
 }

--- a/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
@@ -46,7 +46,7 @@ public class GroupServiceImpl implements GroupService {
             throw new GroupException(GroupErrorCode.GROUP_NAME_DUPLICATE);
         }
 
-        Group createdGroup = Group.createGroup(leader, groupName, groupIntro, groupCapacity);
+        Group createdGroup = Group.createGroup(leader, groupName, groupIntro, groupCapacity, createGroupDto.fileName());
         groupRepository.save(createdGroup);
 
         GroupMember leaderMember = GroupMember.create(createdGroup, leader);


### PR DESCRIPTION
- close #262 

기존 그룹 생성 시, 이미지 업로드 오류 수정했습니다.
API 테스트 완

<img width="1447" height="189" alt="image" src="https://github.com/user-attachments/assets/d27798d8-d311-4991-a2e5-2229a6934f59" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Groups can now be created with a designated cover image file name, enabling customized group presentation during setup.

* **Chores**
  * Enhanced internal logging for file upload operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->