### PR TITLE
bugfix: 게시글 이미지 업로드 문제 해결 (3장부터는 업로드 안되는 문제)

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/post/domain/Post.java
+++ b/src/main/java/com/kakaotechcampus/team16be/post/domain/Post.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,6 +33,12 @@ public class Post extends BaseEntity {
     @Column(length = 1000)
     private String content;
 
+    @ElementCollection
+    @CollectionTable(
+            name = "post_image_urls",
+            joinColumns = @JoinColumn(name = "post_id")
+    )
+    @Column(name = "image_url", length = 1000)
     private List<String> imageUrls = new ArrayList<>();
 
     private Long likeCount = 0L;
@@ -45,7 +52,7 @@ public class Post extends BaseEntity {
         this.imageUrls = imageUrls;
     }
 
-    public static Post createPost(String userNickname,Group group, String title, String content, List<String> imageUrls) {
+    public static Post createPost(String userNickname, Group group, String title, String content, List<String> imageUrls) {
         return com.kakaotechcampus.team16be.post.domain.Post.builder()
                 .author(userNickname)
                 .group(group)


### PR DESCRIPTION
### 관련이슈
- close #266 

### 에러메시지
```
{
    "message": "could not execute statement [(conn=17073) Data too long for column 'image_urls' at row 1] [insert into posts (author,content,created_at,group_id,image_urls,like_count,title,updated_at) values (?,?,?,?,?,?,?,?)]; SQL [insert into posts (author,content,created_at,group_id,image_urls,like_count,title,updated_at) values (?,?,?,?,?,?,?,?)]",
    "code": "UNEXPECTED_ERROR",
    "status": 500
}
```

### 원인:
- `Post` 엔티티에서 `List<String> imageUrls`를 그냥 선언하여 JPA가 컬렉션을 인식하지 못함.
- JPA는 리스트 전체를 하나의 문자열로 직렬화하여 `image_urls` 컬럼(VARCHAR)에 저장하려고 시도함.
- 3개 이상 이미지 URL이 들어가면 문자열 길이가 컬럼 제한을 초과하여 오류 발생.

### 기존 엔티티 예시:
```
private List<String> imageUrls = new ArrayList<>();
```

### 문제 요약:
- DB는 배열 개념이 없으므로, 리스트를 문자열 하나로 취급
- 1~2개 이미지 URL은 통과, 3개 이상이면 길이 초과
- 단순히 VARCHAR → TEXT로 바꿔도 조회나 쿼리 조건 등에서 문제가 발생함

### 해결 방법:
- `@ElementCollection`을 사용하여 이미지 URL을 별도 테이블(`post_image_urls`)로 분리
- Post 객체 내에서는 여전히 `List<String>`으로 유지
- DB는 1:N 구조로 분리되어 저장되므로 제한 없이 이미지 저장 가능

### 수정 엔티티 예시:
```
@ElementCollection
@CollectionTable(
    name = "post_image_urls",
    joinColumns = @JoinColumn(name = "post_id")
)
@Column(name = "image_url", length = 1000)
private List<String> imageUrls = new ArrayList<>();
```

### 결과:
- 이미지 URL 리스트를 안전하게 저장 가능
- 기존 데이터 구조 유지

### 스크린샷
<img width="660" height="141" alt="image" src="https://github.com/user-attachments/assets/f536cd4d-edf8-4b76-87dc-350031668012" />

<img width="352" height="112" alt="image" src="https://github.com/user-attachments/assets/852e610a-64e9-4c46-909c-cea34f57b1a6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Posts now support multiple image attachments for enhanced content creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->