### PR TITLE
feat:그룹별 멤버 조회 userId 추가 및 모두 조회

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/GroupMemberDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/dto/GroupMemberDto.java
@@ -8,6 +8,7 @@ import java.util.List;
 public record GroupMemberDto(
         Long id,
         String groupName,
+        Long userId,
         String nickname,
         GroupRole groupRole,
         String profileImageUrl
@@ -18,6 +19,7 @@ public record GroupMemberDto(
                 .map(member -> new GroupMemberDto(
                         member.getId(),
                         member.getGroup().getName(),
+                        member.getUser().getId(),
                         member.getUser().getNickname(),
                         member.getRole(),
                         member.getUser().getProfileImageUrl()

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
@@ -122,7 +122,6 @@ public class GroupMemberServiceImpl implements GroupMemberService {
     @Override
     @Transactional(readOnly = true)
     public List<GroupMemberDto> getGroupMember(User user, Long groupId) {
-        validateGroupMember(user, groupId);
         Group targetGroup = groupService.findGroupById(groupId);
         List<GroupMember> members = groupMemberRepository.findAllByGroupAndStatus(targetGroup,ACTIVE);
 
@@ -135,6 +134,7 @@ public class GroupMemberServiceImpl implements GroupMemberService {
                     return new GroupMemberDto(
                             member.getId(),
                             member.getGroup().getName(),
+                            memberUser.getId(),
                             memberUser.getNickname(),
                             member.getRole(),
                             publicUrl

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
@@ -129,7 +129,12 @@ public class GroupMemberServiceImpl implements GroupMemberService {
                 .map(member -> {
                     User memberUser = member.getUser();
                     String originalUrl = memberUser.getProfileImageUrl();
-                    String publicUrl = s3UploadPresignedUrlService.getPublicUrl(originalUrl);
+                    String publicUrl;
+                    if (originalUrl==null||originalUrl.isEmpty()) {
+                        publicUrl = s3UploadPresignedUrlService.getPublicUrl("");
+                    } else {
+                        publicUrl = s3UploadPresignedUrlService.getPublicUrl(originalUrl);
+                    }
 
                     return new GroupMemberDto(
                             member.getId(),

--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberServiceImpl.java
@@ -130,7 +130,7 @@ public class GroupMemberServiceImpl implements GroupMemberService {
                     User memberUser = member.getUser();
                     String originalUrl = memberUser.getProfileImageUrl();
                     String publicUrl;
-                    if (originalUrl==null||originalUrl.isEmpty()) {
+                    if (originalUrl == null || originalUrl.isEmpty()) {
                         publicUrl = s3UploadPresignedUrlService.getPublicUrl("");
                     } else {
                         publicUrl = s3UploadPresignedUrlService.getPublicUrl(originalUrl);


### PR DESCRIPTION
<img width="944" height="620" alt="image" src="https://github.com/user-attachments/assets/ee17e935-a31e-4417-8ff4-060d4e3eb540" />


반환 값에 userId를 추가하였고, 조회 조건 제거했습니다.
추가로 이미지 반환 오류 수정했습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group member responses now include each member's user ID.

* **Bug Fixes**
  * Profile image URLs now handle null or empty values and generate a usable public URL when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->