### PR TITLE
fix : 좋아요 및 댓글이 있는 게시글 삭제 오류

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/comment/domain/Comment.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/domain/Comment.java
@@ -26,6 +26,7 @@ public class Comment extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "post_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Post post;
 
     @ManyToOne

--- a/src/main/java/com/kakaotechcampus/team16be/comment/domain/Comment.java
+++ b/src/main/java/com/kakaotechcampus/team16be/comment/domain/Comment.java
@@ -25,7 +25,7 @@ public class Comment extends BaseEntity {
     private String content;
 
     @ManyToOne
-    @JoinColumn(name = "post_id")
+    @JoinColumn(name = "post_id", nullable = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Post post;
 

--- a/src/main/java/com/kakaotechcampus/team16be/like/domain/Like.java
+++ b/src/main/java/com/kakaotechcampus/team16be/like/domain/Like.java
@@ -8,6 +8,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -27,6 +29,7 @@ public class Like extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "post_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Post post;
 
     @Builder


### PR DESCRIPTION
-close #272 

좋아요 및 댓글이 있는 게시글 삭제가 안되는 오류가 발견되어 db 작업 및 엔티티 수정했습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data integrity: comments and likes are now automatically removed when their associated posts are deleted, preventing orphaned records and ensuring consistent post-related data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->