### PR TITLE
bugfix: 알림(Notification) 관련 문제 수정 

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/notification/domain/Notification.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/domain/Notification.java
@@ -42,8 +42,19 @@ public class Notification extends BaseEntity {
     @Column(nullable = false)
     private boolean isReviewed = false;
 
+    @Column(nullable = false)
+    private boolean isRead = false;
+
     @Builder
-    public Notification(User receiver, boolean isReviewed, NotificationType notificationType, Group relatedGroup, User relatedUser, String nickname ,String message) {
+    public Notification(User receiver,
+                        boolean isReviewed,
+                        NotificationType notificationType,
+                        Group relatedGroup,
+                        User relatedUser,
+                        String nickname,
+                        String message,
+                        boolean isRead
+    ) {
         this.receiver = receiver;
         this.notificationType = notificationType;
         this.relatedGroup = relatedGroup;
@@ -51,6 +62,7 @@ public class Notification extends BaseEntity {
         this.nickname = nickname;
         this.message = message;
         this.isReviewed = isReviewed;
+        this.isRead = isRead;
     }
 
     public static Notification createNotification(User receiver, Notification notificationType, Group relatedGroup, User relatedUser) {

--- a/src/main/java/com/kakaotechcampus/team16be/notification/dto/ResponseNotification.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/dto/ResponseNotification.java
@@ -26,6 +26,6 @@ public record ResponseNotification(
                 notification.getNickname(),
                 notification.getMessage(),
                 notification.isReviewed(),
-                notification.getIsRead());
+                notification.isRead());
     }
 }


### PR DESCRIPTION
### 관련 이슈
- close #276 

### 문제 원인
- isRead : 리뷰 작성이 완료된 알림의 경우 isRead=True 처리를 하고 있는데 실제 DB에는 저장되지 않고 있는 문제를 해결하였음. 엔티티에 isRead필드가 추가되어있지 않아 오류가 생겼었음.

### 🎯 주요 변경사항  

**Notification 엔티티 수정**
   - `isReviewed` 필드 추가 및 기본값 설정 (`@Column(nullable = false)`)
   - `@Builder` 생성자에 `isReviewed` 포함
   - 관련 필드들(`receiver`, `relatedGroup`, `relatedUser`, `nickname`, `message`, `notificationType`) 구조 정리  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read status tracking for notifications, enabling users to distinguish between viewed and unviewed notifications for improved organization and visibility management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->