### PR TITLE
feat: 관리자 로그인/로그아웃 및 인증 필터 추가로 관리자 페이지 접근 제어 기능 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,9 @@ name: Deploy to EC2 with GitHub Actions
 
 on:
   push:
-    branches: [develop]
+    branches: [ develop ]
   pull_request:
-    branches: [develop]
+    branches: [ develop ]
 
 jobs:
   build-and-deploy:
@@ -127,6 +127,7 @@ jobs:
             export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
             export DEFAULT_IMG=${{ secrets.DEFAULT_IMG }}
             export FRONT_REDIRECT_URI=${{ secrets.FRONT_REDIRECT_URI }}
+            export ADMIN_PASSWORD=${{ secrets.ADMIN_PASSWORD }}
             
             APP_DIR="/home/${USER}/Team16_BE"
             JAR_NAME="${{ steps.find_jar.outputs.JAR_NAME }}"

--- a/src/main/java/com/kakaotechcampus/team16be/admin/controller/AdminAuthPageController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/admin/controller/AdminAuthPageController.java
@@ -1,0 +1,44 @@
+package com.kakaotechcampus.team16be.admin.controller;
+
+import jakarta.servlet.http.HttpSession;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("/admin")
+public class AdminAuthPageController {
+
+    @Value("${admin.password}")
+    private String ADMIN_PASSWORD;
+
+    @GetMapping("/login")
+    public String loginPage() {
+        return "admin/login";
+    }
+
+    @PostMapping("/login")
+    public String login(
+            @RequestParam("password") String password,
+            HttpSession session,
+            Model model
+    ) {
+        if (ADMIN_PASSWORD.equals(password)) {
+            session.setAttribute("isAdmin", true);
+            return "redirect:/admin/student-verifications";
+        } else {
+            model.addAttribute("error", "비밀번호가 올바르지 않습니다.");
+            return "admin/login";
+        }
+    }
+
+    @GetMapping("/logout")
+    public String logout(HttpSession session) {
+        session.invalidate();
+        return "redirect:/admin/login";
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/admin/filter/AdminAuthFilter.java
+++ b/src/main/java/com/kakaotechcampus/team16be/admin/filter/AdminAuthFilter.java
@@ -1,0 +1,37 @@
+package com.kakaotechcampus.team16be.admin.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class AdminAuthFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpServletResponse res = (HttpServletResponse) response;
+
+        String uri = req.getRequestURI();
+
+        // 로그인 페이지와 리소스는 필터 제외
+        if (uri.startsWith("/admin/login") || uri.startsWith("/css") || uri.startsWith("/js") || uri.startsWith("/images")) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        HttpSession session = req.getSession(false);
+        boolean isAdmin = session != null && Boolean.TRUE.equals(session.getAttribute("isAdmin"));
+
+        if (!isAdmin) {
+            res.sendRedirect("/admin/login");
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/kakaotechcampus/team16be/common/config/Webconfig.java
+++ b/src/main/java/com/kakaotechcampus/team16be/common/config/Webconfig.java
@@ -41,9 +41,8 @@ public class Webconfig implements WebMvcConfigurer {
 
         registry.addInterceptor(adminCheckInterceptor)
                 .addPathPatterns(
-                        "/api/admin/**",
-                        "/admin/**"
-                        ); // 관리자만 접근
+                        "/api/admin/**"
+                ); // 관리자만 접근
 
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 spring.application.name=Team16-BE
 spring.config.import=optional:file:.env[.properties]
-
 # H2 ?? ???? ?? ?.
 # spring.datasource.driver-class-name=org.h2.Driver
 # spring.datasource.url=jdbc:h2:mem:testdb
@@ -8,39 +7,32 @@ spring.config.import=optional:file:.env[.properties]
 # spring.datasource.password=
 # spring.h2.console.enabled=true
 # spring.h2.console.path=/h2-console
-
 # Maria DB
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 spring.datasource.url=jdbc:mariadb://${DB_HOST}:${DB_PORT}/${DB_NAME}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
-
 # JPA
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
 spring.jpa.properties.hibernate.default_batch_fetch_size=50
-
 # jwt
 jwt.secret=${JWT_SECRET_KEY}
-
 # kakao
 kakao.client-id=${KAKAO_CLIENT_ID}
 kakao.redirect-uri=${KAKAO_REDIRECT_URI}
-
 # 프론트엔드로 리다이렉트할 URI
 front.redirect-uri=${FRONT_REDIRECT_URI}
-
 server.address=0.0.0.0
 server.port=8080
-
 #s3
 cloud.aws.region.static=${AWS_REGION}
 cloud.aws.s3.bucket=${AWS_S3_BUCKET}
 cloud.aws.credentials.access-key=${AWS_ACCESS_KEY_ID}
 cloud.aws.credentials.secret-key=${AWS_SECRET_ACCESS_KEY}
 cloud.aws.stack.auto=false
-
 #s3 defaultImg
 cloud.aws.s3.default-image-url=${DEFAULT_IMG}
-
+# adminPage Password
+admin.password=${ADMIN_PASSWORD}

--- a/src/main/resources/templates/admin/adminPage.html
+++ b/src/main/resources/templates/admin/adminPage.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>학생증 인증 요청 관리</title>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8"/>
     <style>
         /* --- 전체 레이아웃 --- */
         body {
@@ -20,7 +20,7 @@
             padding: 20px;
             background-color: #fff;
             border-radius: 12px;
-            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
         }
 
         h2 {
@@ -51,6 +51,14 @@
 
         .nav-btn:hover {
             background-color: #45a049;
+        }
+
+        .logout-btn {
+            background-color: #555;
+        }
+
+        .logout-btn:hover {
+            background-color: #333;
         }
 
         /* --- 테이블 --- */
@@ -127,7 +135,7 @@
             width: 100%;
             height: 100%;
             overflow: auto;
-            background-color: rgba(0,0,0,0.8);
+            background-color: rgba(0, 0, 0, 0.8);
         }
 
         .modal-content {
@@ -136,7 +144,7 @@
             max-width: 80%;
             max-height: 80%;
             border-radius: 8px;
-            box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
         }
 
         .close {
@@ -196,11 +204,25 @@
                 font-weight: 700;
             }
 
-            td:nth-of-type(1):before { content: "ID"; }
-            td:nth-of-type(2):before { content: "닉네임"; }
-            td:nth-of-type(3):before { content: "학생증 이미지"; }
-            td:nth-of-type(4):before { content: "상태"; }
-            td:nth-of-type(5):before { content: "조치"; }
+            td:nth-of-type(1):before {
+                content: "ID";
+            }
+
+            td:nth-of-type(2):before {
+                content: "닉네임";
+            }
+
+            td:nth-of-type(3):before {
+                content: "학생증 이미지";
+            }
+
+            td:nth-of-type(4):before {
+                content: "상태";
+            }
+
+            td:nth-of-type(5):before {
+                content: "조치";
+            }
         }
     </style>
 </head>
@@ -214,6 +236,7 @@
         <a th:href="@{/admin/scores}" class="nav-btn">유저 점수 관리</a>
         <a th:href="@{/admin/groups}" class="nav-btn">그룹 안전 상태 관리</a>
         <a th:href="@{/admin/reports}" class="nav-btn">신고 관리 페이지</a>
+        <a th:href="@{/admin/logout}" class="nav-btn logout-btn">로그아웃</a>
     </div>
 
     <!-- 테이블 -->
@@ -237,13 +260,13 @@
             <td th:text="${v.verificationStatus}"></td>
             <td>
                 <form th:action="@{/admin/student-verifications/update}" method="post" style="display:inline;">
-                    <input type="hidden" name="userId" th:value="${v.userId}" />
-                    <input type="hidden" name="status" value="VERIFIED" />
+                    <input type="hidden" name="userId" th:value="${v.userId}"/>
+                    <input type="hidden" name="status" value="VERIFIED"/>
                     <button type="submit" class="approve">승인</button>
                 </form>
                 <form th:action="@{/admin/student-verifications/update}" method="post" style="display:inline;">
-                    <input type="hidden" name="userId" th:value="${v.userId}" />
-                    <input type="hidden" name="status" value="UNVERIFIED" />
+                    <input type="hidden" name="userId" th:value="${v.userId}"/>
+                    <input type="hidden" name="status" value="UNVERIFIED"/>
                     <button type="submit" class="reject">거절</button>
                 </form>
             </td>

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>관리자 로그인</title>
+    <style>
+        body {
+            font-family: 'Segoe UI';
+            background-color: #f4f6f8;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+        }
+
+        .login-box {
+            background-color: white;
+            padding: 30px 40px;
+            border-radius: 12px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+            text-align: center;
+            width: 320px;
+        }
+
+        h2 {
+            margin-bottom: 20px;
+        }
+
+        input[type="password"] {
+            width: 100%;
+            padding: 10px;
+            border-radius: 8px;
+            border: 1px solid #ccc;
+            margin-bottom: 20px;
+        }
+
+        button {
+            width: 100%;
+            padding: 10px;
+            border: none;
+            border-radius: 8px;
+            background-color: #4CAF50;
+            color: white;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        button:hover {
+            background-color: #45a049;
+        }
+
+        .error {
+            color: red;
+            margin-bottom: 10px;
+        }
+    </style>
+</head>
+<body>
+<div class="login-box">
+    <h2>관리자 로그인</h2>
+    <form th:action="@{/admin/login}" method="post">
+        <div th:if="${error}" class="error" th:text="${error}"></div>
+        <input type="password" name="password" placeholder="비밀번호 입력" required/>
+        <button type="submit">로그인</button>
+    </form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
### 관련 이슈
- close #278 

### 🔐 관리자 로그인 기능 구현

#### 주요 변경사항
1. **관리자 로그인 페이지 및 인증 로직 추가**
   - `/admin/login` GET: 로그인 페이지 반환
   - `/admin/login` POST: 입력한 비밀번호를 환경변수(`admin.password`) 값과 비교하여 인증 수행  
   - 인증 성공 시 세션에 `isAdmin=true` 저장, 실패 시 에러 메시지 반환  

2. **로그아웃 기능 추가**
   - `/admin/logout`: 세션 무효화 후 로그인 페이지로 리다이렉트  
   - 로그아웃 버튼을 관리자 메인 페이지에만 추가하였음

3. **관리자 인증 필터(`AdminAuthFilter`) 추가**
   - `/admin/login`, `/css`, `/js`, `/images` 요청은 필터 제외  
   - 세션에 `isAdmin` 값이 없는 경우 `/admin/login`으로 리다이렉트  
   - 관리자가 아닌 사용자의 접근을 차단  

4. **보안 강화**
   - 관리자 비밀번호를 코드에 직접 하드코딩하지 않고, 환경 변수(`application.yml`)로 관리  

#### 추가 변경사항
- `WebConfig`의 `addInterceptor`에서 `/admin/**` 경로 제외 → 필터에서 처리하도록 변경
