### PR TITLE
refactor: (신고 관리자 페이지) 신고 컨트롤러 수정 및 권한 검증 방식 변경

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/admin/controller/AdminPageController.java
+++ b/src/main/java/com/kakaotechcampus/team16be/admin/controller/AdminPageController.java
@@ -9,7 +9,10 @@ import com.kakaotechcampus.team16be.group.domain.SafetyTag;
 import com.kakaotechcampus.team16be.group.service.GroupService;
 import com.kakaotechcampus.team16be.user.domain.User;
 import com.kakaotechcampus.team16be.user.service.UserService;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -94,9 +97,14 @@ public class AdminPageController {
     public String updateReportStatus(
             @RequestParam("reportId") Long reportId,
             @RequestParam("status") String status,
-            @LoginUser User adminUser
+            HttpSession session
     ) {
-        adminPageService.updateReportStatus(reportId, status, adminUser);
+        Boolean isAdmin = (Boolean) session.getAttribute("isAdmin");
+        if (isAdmin == null || !isAdmin) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body("관리자 권한이 필요합니다.").toString();
+        }
+        adminPageService.updateReportStatus(reportId, status);
         return "redirect:/admin/reports";
     }
 

--- a/src/main/java/com/kakaotechcampus/team16be/admin/dto/AdminReportResponseDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/admin/dto/AdminReportResponseDto.java
@@ -12,9 +12,10 @@ public class AdminReportResponseDto {
     private final String targetType;
     private final Long targetId;
     private final String createdAt;
+    private final String resolvedByNickname;
 
     private AdminReportResponseDto(Long id, String reporterNickname, String reason, String status,
-                                   String targetType, Long targetId, String createdAt) {
+                                   String targetType, Long targetId, String createdAt, String resolvedByNickname) {
         this.id = id;
         this.reporterNickname = reporterNickname;
         this.reason = reason;
@@ -22,9 +23,14 @@ public class AdminReportResponseDto {
         this.targetType = targetType;
         this.targetId = targetId;
         this.createdAt = createdAt;
+        this.resolvedByNickname = resolvedByNickname;
     }
 
     public static AdminReportResponseDto from(Report report) {
+        String resolvedByNick = report.getResolvedBy() != null
+                ? report.getResolvedBy().getNickname()
+                : "관리자"; // null이면 관리자 표시
+
         return new AdminReportResponseDto(
                 report.getId(),
                 report.getReporter().getNickname(),
@@ -32,7 +38,8 @@ public class AdminReportResponseDto {
                 report.getStatus().name(),
                 report.getTargetType().name(),
                 report.getTargetId(),
-                report.getCreatedAt().toString()
+                report.getCreatedAt().toString(),
+                resolvedByNick
         );
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/admin/service/AdminPageService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/admin/service/AdminPageService.java
@@ -56,11 +56,10 @@ public class AdminPageService {
     }
 
     @Transactional
-    public void updateReportStatus(Long reportId, String status, User resolvedBy) {
+    public void updateReportStatus(Long reportId, String status) {
         Report report = reportRepository.findById(reportId)
                 .orElseThrow(() -> new ReportException(ReportErrorCode.REPORT_NOT_FOUND));
-
-        report.updateStatus(status, resolvedBy);
+        report.updateStatusAsAdmin(status);
     }
 
 }

--- a/src/main/java/com/kakaotechcampus/team16be/report/domain/Report.java
+++ b/src/main/java/com/kakaotechcampus/team16be/report/domain/Report.java
@@ -94,6 +94,7 @@ public class Report extends BaseEntity {
         this.resolvedAt = LocalDateTime.now();
     }
 
+
     public enum ReasonCode {
         RELIGION_SUSPECT,
         NOT_HEALTHY_PURPOSE,
@@ -106,9 +107,9 @@ public class Report extends BaseEntity {
         return this.status != null ? this.status : ReportStatus.PENDING;
     }
 
-    public void updateStatus(String newStatus, User resolvedBy) {
-        this.status = ReportStatus.valueOf(newStatus);
-        this.resolvedBy = resolvedBy;
+    public void updateStatusAsAdmin(String status) {
+        this.status = ReportStatus.valueOf(status);
+        this.resolvedBy = null; // 시스템(관리자)에 의해 처리됨
         this.resolvedAt = LocalDateTime.now();
     }
 }

--- a/src/main/resources/templates/admin/adminReports.html
+++ b/src/main/resources/templates/admin/adminReports.html
@@ -20,7 +20,7 @@
             padding: 20px;
             background-color: #fff;
             border-radius: 12px;
-            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
         }
 
         h2 {
@@ -134,12 +134,29 @@
                 font-weight: 700;
             }
 
-            td:nth-of-type(1):before { content: "신고 ID"; }
-            td:nth-of-type(2):before { content: "대상 유형"; }
-            td:nth-of-type(3):before { content: "대상 ID"; }
-            td:nth-of-type(4):before { content: "신고 사유"; }
-            td:nth-of-type(5):before { content: "신고 상태"; }
-            td:nth-of-type(6):before { content: "처리"; }
+            td:nth-of-type(1):before {
+                content: "신고 ID";
+            }
+
+            td:nth-of-type(2):before {
+                content: "대상 유형";
+            }
+
+            td:nth-of-type(3):before {
+                content: "대상 ID";
+            }
+
+            td:nth-of-type(4):before {
+                content: "신고 사유";
+            }
+
+            td:nth-of-type(5):before {
+                content: "신고 상태";
+            }
+
+            td:nth-of-type(6):before {
+                content: "처리";
+            }
         }
     </style>
 </head>
@@ -164,6 +181,7 @@
             <th>대상 ID</th>
             <th>신고 사유</th>
             <th>신고 상태</th>
+            <th>처리자</th>
             <th>처리</th>
         </tr>
         </thead>
@@ -174,10 +192,11 @@
             <td th:text="${r.targetId}"></td>
             <td th:text="${r.reason}"></td>
             <td th:text="${r.status}"></td>
+            <td th:text="${r.resolvedByNickname != null ? r.resolvedByNickname : '-'}"></td>
             <td>
                 <form th:if="${r.status == 'PENDING'}"
                       th:action="@{/admin/reports/update}" method="post" style="display:inline;">
-                    <input type="hidden" name="reportId" th:value="${r.id}" />
+                    <input type="hidden" name="reportId" th:value="${r.id}"/>
                     <select name="status">
                         <option value="RESOLVED">승인</option>
                         <option value="REJECTED">거절</option>


### PR DESCRIPTION
### 관련 이슈
- close #280 

### 변경 사항
- 기존 @LoginUser 기반 관리자 인증 방식에서 세션 기반 isAdmin 검증으로 변경
- 관리자가 아닌 경우 403 Forbidden 응답 반환하도록 로직 추가
- 처리 상태가 PENDING일 때만 처리 폼 표시, 완료된 경우 "처리 완료"로 표시


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new report reason categories (Inappropriate, Fraud/Privacy, Other) to expand reporting options.
  * Added resolver column in admin reports page to display which administrator processed each report.

* **Improvements**
  * Enhanced authorization mechanism for report status updates through session-based access control.
  * Improved admin report table structure and accessibility with better formatting and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->