### PR TITLE
bugfix: AdminAuthFilter 개선 - Admin 페이지만 보호, API 요청과 preflight 제외

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/admin/filter/AdminAuthFilter.java
+++ b/src/main/java/com/kakaotechcampus/team16be/admin/filter/AdminAuthFilter.java
@@ -18,8 +18,17 @@ public class AdminAuthFilter implements Filter {
 
         String uri = req.getRequestURI();
 
-        // 로그인 페이지와 리소스는 필터 제외
-        if (uri.startsWith("/admin/login") || uri.startsWith("/css") || uri.startsWith("/js") || uri.startsWith("/images")) {
+        // 로그인 페이지, 정적 리소스, API 요청은 필터 제외
+        if (uri.startsWith("/admin/login") ||
+                uri.startsWith("/css") || uri.startsWith("/js") || uri.startsWith("/images") ||
+                uri.startsWith("/api")) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // preflight 요청(OPTIONS)은 인증 없이 통과
+        if ("OPTIONS".equalsIgnoreCase(req.getMethod())) {
+            res.setStatus(HttpServletResponse.SC_OK);
             chain.doFilter(request, response);
             return;
         }


### PR DESCRIPTION
## 관련 이슈
- close #282 

## 📌 변경 사항

### 1. AdminAuthFilter 개선
- Admin 페이지 접근만 인증 체크하도록 수정
- `/api/**` 요청과 정적 리소스(`/css`, `/js`, `/images`)는 필터 통과
- 브라우저 CORS preflight 요청(`OPTIONS`)은 인증 없이 통과
- 인증되지 않은 Admin 페이지 접근 시 `/admin/login`으로 리다이렉트

### 2. 결과
- Admin 페이지만 보호되고, REST API 호출 시 CORS 문제 해결
- 기존 `/api/users/me` 호출 시 발생하던 preflight 오류 제거


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added support for CORS preflight requests in the admin authentication flow.
  * Extended authentication exclusions to include API routes and static resource paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->