### PR TITLE
feat: ImageFileExtension enum 확장자 목록 확대

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/aws/domain/ImageFileExtension.java
+++ b/src/main/java/com/kakaotechcampus/team16be/aws/domain/ImageFileExtension.java
@@ -11,8 +11,15 @@ import lombok.RequiredArgsConstructor;
 public enum ImageFileExtension {
 
     JPG("jpg"),
+    JPEG("jpeg"),
     PNG("png"),
-    HEIC("heic");
+    HEIC("heic"),
+    HEIF("heif"),
+    GIF("gif"),
+    BMP("bmp"),
+    TIFF("tiff"),
+    TIF("tif"),
+    WEBP("webp");
 
     private final String uploadExtension;
 }


### PR DESCRIPTION
### 관련 이슈
- close #296 

### 🐛 버그 수정: S3 이미지 업로드 시 특정 확장자 업로드 불가 문제 해결  

- `ImageFileExtension` enum에 누락된 이미지 확장자(`jpeg`, `heif`, `gif`, `bmp`, `tiff`, `tif`, `webp`) 추가  
- 기존에는 `jpg`, `png`, `heic`만 허용되어 iPhone 등에서 업로드 시 `JPEG`, `HEIF` 형식 파일이 거부되는 문제 발생  
- 다양한 디바이스(특히 iOS, Android)의 기본 이미지 확장자 지원으로 업로드 호환성 개선  

✅ **변경사항**  
- `ImageFileExtension` enum 확장자 목록 확대  
- `jpeg`, `heif`, `gif`, `bmp`, `tiff`, `tif`, `webp` 추가  

🎯 **결과**  
- 모든 일반적인 스마트폰 및 브라우저 이미지 업로드 정상 동작  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended image format support to include JPEG, HEIF, GIF, BMP, TIFF, and WEBP alongside existing formats, enabling users to upload a broader range of image types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->