### PR TITLE
fix: 게시물 피드 시간 한국 시간 기준으로 변환

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/post/dto/GetPostResponse.java
+++ b/src/main/java/com/kakaotechcampus/team16be/post/dto/GetPostResponse.java
@@ -4,6 +4,7 @@ import com.kakaotechcampus.team16be.post.domain.Post;
 import com.kakaotechcampus.team16be.user.domain.User;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 public record GetPostResponse(
@@ -21,6 +22,11 @@ public record GetPostResponse(
         boolean isLike
 ) {
     public static GetPostResponse from(Post post, User author, String authorProfileImageUrl, List<String> fullURLs, Integer commentCount, boolean isLike) {
+        LocalDateTime createdAtKst = post.getCreatedAt()
+                .atZone(ZoneId.of("UTC"))
+                .withZoneSameInstant(ZoneId.of("Asia/Seoul"))
+                .toLocalDateTime();
+
         return new GetPostResponse(
                 post.getId(),
                 post.getGroup().getId(),
@@ -32,7 +38,7 @@ public record GetPostResponse(
                 fullURLs,
                 post.getLikeCount(),
                 commentCount,
-                post.getCreatedAt(),
+                createdAtKst,
                 isLike
         );
     }

--- a/src/main/java/com/kakaotechcampus/team16be/post/service/PostFacadeService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/post/service/PostFacadeService.java
@@ -48,8 +48,7 @@ public class PostFacadeService {
         String authorProfilePublicUrl = (authorProfileImageUrl != null && !authorProfileImageUrl.isEmpty()) ? s3UploadPresignedUrlService.getPublicUrl(authorProfileImageUrl) : s3UploadPresignedUrlService.getPublicUrl("");
 
 
-
-        return GetPostResponse.from(post, author,authorProfilePublicUrl,fullURLs, commentCount, postLikeResponse.isLiked());
+        return GetPostResponse.from(post, author, authorProfilePublicUrl, fullURLs, commentCount, postLikeResponse.isLiked());
     }
 
     @Transactional(readOnly = true)
@@ -94,7 +93,15 @@ public class PostFacadeService {
                     User author = post.getAuthor();
                     String profileImageUrl = author.getProfileImageUrl();
                     String authorProfilePublicUrl = (profileImageUrl != null && !profileImageUrl.isEmpty()) ? s3UploadPresignedUrlService.getPublicUrl(profileImageUrl) : s3UploadPresignedUrlService.getPublicUrl("");
-                    return GetPostResponse.from(post,author, authorProfilePublicUrl,fullURLs, commentCount,postLikeResponse.isLiked());
+
+                    return GetPostResponse.from(
+                            post,
+                            author,
+                            authorProfilePublicUrl,
+                            fullURLs,
+                            commentCount,
+                            postLikeResponse.isLiked()
+                    );
                 })
                 .toList();
     }


### PR DESCRIPTION
### 관련 이슈
- close #303 

### 내용
- Post 조회 시 UTC 기준 내림차순 정렬 유지
- GetPostResponse DTO 생성 시 createdAt을 KST(Asia/Seoul) 기준으로 변환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Post creation timestamps are now displayed in Asia/Seoul timezone, providing accurate local time representation for improved user experience. Timestamps will reflect your local timezone rather than UTC, making it easier to understand when posts were created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->