### PR TITLE
fix: UpdateGroupDto 모임 이름 유효성 검사 길이 10자로 확장

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/group/dto/UpdateGroupDto.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/dto/UpdateGroupDto.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record UpdateGroupDto(
-        @Size(min = 2, max = 8, message = "모임 이름은 2자 이상 8자 이하입니다.")
+        @Size(min = 2, max = 10, message = "모임 이름은 2자 이상 10자 이하입니다.")
         @Pattern(regexp = "^[a-zA-Z0-9가-힣]+$", message = "특수문자를 사용할 수 없습니다.")
         String name,
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum length for group names from 8 to 10 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->