### PR TITLE
bugfix: 알림 메시지 내용과 닉네임이 올바르게 표시되도록 수정

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberFacade.java
+++ b/src/main/java/com/kakaotechcampus/team16be/groupMember/service/GroupMemberFacade.java
@@ -70,14 +70,14 @@ public class GroupMemberFacade {
                 throw new GroupMemberException(GroupMemberErrorCode.ALREADY_JOIN_REQUESTED);
             } else if (status.isCanceled() || status.isLeft()) {
                 existingMember.updateIntroAndStatus(intro, GroupMemberStatus.PENDING);
-                notificationService.createGroupSignNotification(targetGroup.getLeader(), targetGroup);
+                notificationService.createGroupSignNotification(signedUser, targetGroup);
                 return groupMemberRepository.save(existingMember);
             }
         }
 
         // 기존 레코드가 없으면 새로 생성
         GroupMember signMember = GroupMember.sign(signedUser, targetGroup, intro);
-        notificationService.createGroupSignNotification(targetGroup.getLeader(), targetGroup);
+        notificationService.createGroupSignNotification(signedUser, targetGroup);
         return groupMemberRepository.save(signMember);
     }
 

--- a/src/main/java/com/kakaotechcampus/team16be/notification/domain/Notification.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/domain/Notification.java
@@ -65,17 +65,6 @@ public class Notification extends BaseEntity {
         this.isRead = isRead;
     }
 
-    public static Notification createNotification(User receiver, Notification notificationType, Group relatedGroup, User relatedUser) {
-        return Notification.builder()
-                .receiver(receiver)
-                .notificationType(notificationType.notificationType)
-                .relatedGroup(relatedGroup)
-                .relatedUser(relatedUser)
-                .nickname(relatedUser.getNickname())
-                .message(notificationType.getMessage())
-                .build();
-    }
-
     public static Notification createReviewNotification(User receiver, boolean checkReview, Group relatedGroup, User relatedUser, String message) {
         return Notification.builder()
                 .receiver(receiver)

--- a/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/notification/service/NotificationServiceImpl.java
@@ -156,7 +156,7 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public List<ResponseNotification> getAllNotifications(User user) {
         List<Notification> notifications = notificationRepository.findAllByReceiverOrderByCreatedAtDesc((user));
 
@@ -171,6 +171,7 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Override
+    @Transactional
     public void createGroupRejectNotification(User joinUser, Group targetGroup) {
         Notification notification = Notification.builder()
                 .notificationType(GROUP_JOIN_REJECT)


### PR DESCRIPTION
### 관련 이슈
- close #313 

### 변경 사항
- `notificationService.createGroupSignNotification` 호출 시
  - 메시지에 그룹장 이름이 아닌 요청한 사용자(`signedUser`)의 이름이 표시되도록 수정
- Transactional 어노테이션 빠진 부분들 추가

### 결과
- 가입 요청 알림 메시지에 올바른 사용자 이름 표시
- 기존 로직과 알림 수신자는 그대로 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated group membership notification recipients to be sent to the user applying for membership instead of the group leader.

* **Chores**
  * Removed an unused notification factory method.
  * Optimized transaction handling for notification retrieval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->