### PR TITLE
refactor: 그룹 전체 조회 시 내림차순 반환으로 수정

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/group/domain/Group.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/domain/Group.java
@@ -16,7 +16,6 @@ import java.math.RoundingMode;
 import lombok.Builder;
 import lombok.Getter;
 
-
 @Entity
 @Getter
 @Table(name = "groups")
@@ -27,7 +26,6 @@ public class Group extends BaseEntity {
     private final static Double POSTING = 0.05;
     private final static Double CAUTION_GROUP = 74.0;
     private final static Double DANGER_GROUP = 62.0;
-
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,8 +38,6 @@ public class Group extends BaseEntity {
     private String intro;
 
     private String coverImageUrl;
-
-    private String category;
 
     @Min(1)
     private Integer capacity;

--- a/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
@@ -158,7 +158,7 @@ public class GroupServiceImpl implements GroupService {
     @Transactional
     @Override
     public void updateGroupScoreAndTag(Group group, Double newScore) {
-        group.groupScoreUpdate(newScore);g
+        group.groupScoreUpdate(newScore);
         group.updateSafetyTagByScore();
     }
 }

--- a/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/service/GroupServiceImpl.java
@@ -16,6 +16,7 @@ import com.kakaotechcampus.team16be.user.exception.UserException;
 import com.kakaotechcampus.team16be.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,7 +60,7 @@ public class GroupServiceImpl implements GroupService {
     @Override
     public List<Group> getAllGroups() {
 
-        List<Group> findGroups = groupRepository.findAll();
+      List<Group> findGroups = groupRepository.findAll(Sort.by(Sort.Direction.DESC, "id"));
 
         if (findGroups.isEmpty()) {
             throw new GroupException(GroupErrorCode.GROUP_CANNOT_FOUND);
@@ -72,7 +73,8 @@ public class GroupServiceImpl implements GroupService {
     @Transactional
     @Override
     public void deleteGroup(User user, Long groupId) {
-        User leader = userRepository.findById(user.getId()).orElseThrow(()->new UserException(UserErrorCode.USER_NOT_FOUND));
+        User leader = userRepository.findById(user.getId())
+                                    .orElseThrow(()->new UserException(UserErrorCode.USER_NOT_FOUND));
 
         Group targetGroup = findGroupById(groupId);
         targetGroup.checkLeader(leader);
@@ -85,7 +87,8 @@ public class GroupServiceImpl implements GroupService {
     public Group updateGroup(User user, Long groupId, UpdateGroupDto updateGroupDto) {
         Group targetGroup = findGroupById(groupId);
 
-        User leader = userRepository.findById(user.getId()).orElseThrow(()->new UserException(UserErrorCode.USER_NOT_FOUND));
+        User leader = userRepository.findById(user.getId())
+                                    .orElseThrow(()->new UserException(UserErrorCode.USER_NOT_FOUND));
 
         targetGroup.checkLeader(leader);
 
@@ -94,12 +97,12 @@ public class GroupServiceImpl implements GroupService {
         Integer updatedCapacity = updateGroupDto.capacity();
         targetGroup.update(updatedName, updatedIntro, updatedCapacity);
         return targetGroup;
-
     }
 
     @Override
     public Group findGroupById(Long groupId) {
-        return groupRepository.findById(groupId).orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_CANNOT_FOUND));
+        return groupRepository.findById(groupId)
+                              .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_CANNOT_FOUND));
     }
 
 
@@ -107,7 +110,9 @@ public class GroupServiceImpl implements GroupService {
     @Override
     public Group updateGroupImage(User user, Long groupId, UpdateGroupDto UpdateGroupDto) {
         Group targetGroup = findGroupById(groupId);
-        User leader = userRepository.findById(user.getId()).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        User leader = userRepository.findById(user.getId())
+                                    .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
         targetGroup.checkLeader(leader);
 
         String oldImgUrl = targetGroup.getCoverImageUrl();
@@ -116,7 +121,8 @@ public class GroupServiceImpl implements GroupService {
         targetGroup.changeCoverImage(updatedImgUrl);
 
         boolean isImageChanged = !Objects.equals(updatedImgUrl, oldImgUrl);
-        if (isImageChanged && oldImgUrl != null && !oldImgUrl.isEmpty()) {
+        if (isImageChanged && oldImgUrl != null && !oldImgUrl.isEmpty())
+        {
             eventPublisher.publishEvent(new ImageDeletedEvent(oldImgUrl));
         }
 
@@ -152,7 +158,7 @@ public class GroupServiceImpl implements GroupService {
     @Transactional
     @Override
     public void updateGroupScoreAndTag(Group group, Double newScore) {
-        group.groupScoreUpdate(newScore);   // 점수 갱신
-        group.updateSafetyTagByScore();     // 태그 갱신
+        group.groupScoreUpdate(newScore);g
+        group.updateSafetyTagByScore();
     }
 }


### PR DESCRIPTION
refactor: 그룹 전체 조회 시 내림차순 반환으로 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Groups are now sorted by descending ID when retrieved, displaying groups in reverse ID order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->