### PR TITLE
fix: 닉네임 중복 허용

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/user/domain/User.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/domain/User.java
@@ -23,7 +23,7 @@ public class User extends BaseEntity {
     @Column(name = "kakao_id", unique = true, nullable = false, length = 64)
     private String kakaoId;
 
-    @Column(name = "nickname", unique = true, length = 40)
+    @Column(name = "nickname", length = 40)
     private String nickname;
 
     @Column(name = "profile_image_url", length = 512)


### PR DESCRIPTION
### 관련이슈
- close #316 

### 내용
닉네임 중복을 허용합니다. 기존에 default 닉네임으로 설정해두었던 `익명` 으로 인해서 새로 가입하는 유저들의 닉네임이 중복될 수 밖에 없기 때문입니다.

사실 실무에서 자주 쓰는 this.nickname = "익명_" + kakaoId.substring(0, Math.min(8, kakaoId.length())); 이 방법도 있긴한데 급하게 마감이라 그냥 이렇게 빠르게 수정합니다.