### PR TITLE
feat: 게시글 제목 최대 길이 수정

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/post/dto/CreatePostRequest.java
+++ b/src/main/java/com/kakaotechcampus/team16be/post/dto/CreatePostRequest.java
@@ -10,7 +10,7 @@ public record CreatePostRequest(
         Long groupId,
 
         @NotNull(message = "Title은 필수 값입니다.")
-        @Size(min = 3, max = 15, message = "Title은 3자 이상 15자 이하로 작성해주세요.")
+        @Size(min = 3, max = 50, message = "Title은 3자 이상 50자 이하로 작성해주세요.")
         String title,
 
         @NotNull(message = "Content는 필수 값입니다.")

--- a/src/main/java/com/kakaotechcampus/team16be/post/dto/UpdatePostRequest.java
+++ b/src/main/java/com/kakaotechcampus/team16be/post/dto/UpdatePostRequest.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public record UpdatePostRequest(
 
-        @Size(min = 3, max = 15, message = "Title은 3자 이상 15자 이하로 작성해주세요.")
+        @Size(min = 3, max = 50, message = "Title은 3자 이상 50자 이하로 작성해주세요.")
         String title,
 
         @Size(max = 500, message = "Content는 최대 500자까지 작성 가능합니다.")


### PR DESCRIPTION
### 관련 이슈
- close #335 

### 내용
업데이트할때랑 생성할때 제목 최대 길이를 50자로 늘렸습니다