### PR TITLE
feat: 피드 반환 api에서 게시글이 작성된 그룹 이름을 추가로 반환

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/post/dto/GetPostResponse.java
+++ b/src/main/java/com/kakaotechcampus/team16be/post/dto/GetPostResponse.java
@@ -9,6 +9,7 @@ import java.util.List;
 public record GetPostResponse(
         Long postId,
         Long groupId,
+        String groupName,
         Long authorId,
         String authorNickname,
         String authorProfileImageUrl,
@@ -30,6 +31,7 @@ public record GetPostResponse(
         return new GetPostResponse(
                 post.getId(),
                 post.getGroup().getId(),
+                post.getGroup().getName(),
                 author.getId(),
                 author.getNickname(),
                 authorProfileImageUrl,


### PR DESCRIPTION
### 관련 이슈
- close #337 

### 피드에서 게시글들이 쭉 있는데 게시글이 작성된 그룹의 이름이 뜨는게 좋다고 판단하여 추가했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Post data now includes group names, enabling users to easily identify which group each post belongs to.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->