### PR TITLE
refactor: 소속된 그룹 정보 응답 구조를 Map에서 전용 DTO로 변경

### DIFF
--- a/src/main/java/com/kakaotechcampus/team16be/group/dto/GroupMembership.java
+++ b/src/main/java/com/kakaotechcampus/team16be/group/dto/GroupMembership.java
@@ -1,0 +1,9 @@
+package com.kakaotechcampus.team16be.group.dto;
+
+import java.util.List;
+
+public record GroupMembership(
+        List<String> leaderOf,
+        List<String> memberOf
+) {
+}

--- a/src/main/java/com/kakaotechcampus/team16be/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/dto/UserInfoResponse.java
@@ -1,9 +1,8 @@
 package com.kakaotechcampus.team16be.user.dto;
 
+import com.kakaotechcampus.team16be.group.dto.GroupMembership;
 import com.kakaotechcampus.team16be.user.domain.User;
 import com.kakaotechcampus.team16be.user.domain.VerificationStatus;
-import java.util.List;
-import java.util.Map;
 
 public record UserInfoResponse(
         String id,
@@ -11,9 +10,9 @@ public record UserInfoResponse(
         String profileImageUrl,
         Double userScore,
         VerificationStatus studentVerifiedStatus,
-        Map<String, List<String>> groups
+        GroupMembership groups
 ) {
-    public static UserInfoResponse of(User user, Map<String, List<String>> groups, String profileImageUrl) {
+    public static UserInfoResponse of(User user, GroupMembership groups, String profileImageUrl) {
         return new UserInfoResponse(
                 user.getId().toString(),
                 user.getNickname(),

--- a/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
+++ b/src/main/java/com/kakaotechcampus/team16be/user/service/UserService.java
@@ -7,6 +7,7 @@ import com.kakaotechcampus.team16be.aws.service.S3UploadPresignedUrlService;
 import com.kakaotechcampus.team16be.comment.repository.CommentRepository;
 import com.kakaotechcampus.team16be.groundrule.GroundRuleRepository;
 import com.kakaotechcampus.team16be.group.domain.Group;
+import com.kakaotechcampus.team16be.group.dto.GroupMembership;
 import com.kakaotechcampus.team16be.group.repository.GroupRepository;
 import com.kakaotechcampus.team16be.groupMember.domain.GroupMember;
 import com.kakaotechcampus.team16be.groupMember.domain.GroupMemberStatus;
@@ -27,8 +28,9 @@ import com.kakaotechcampus.team16be.user.dto.UserNicknameResponse;
 import com.kakaotechcampus.team16be.user.exception.UserErrorCode;
 import com.kakaotechcampus.team16be.user.exception.UserException;
 import com.kakaotechcampus.team16be.user.repository.UserRepository;
+
 import java.util.List;
-import java.util.Map;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -147,13 +149,11 @@ public class UserService {
     public UserInfoResponse getUserInfo(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
         List<String> leaderGroupIds = groupRepository.findLeaderGroupIdsByUserId(userId);
         List<String> memberGroupIds = groupRepository.findMemberGroupIdsByUserId(userId);
 
-        Map<String, List<String>> groups = Map.of(
-                "leaderOf", leaderGroupIds,
-                "memberOf", memberGroupIds
-        );
+        GroupMembership groups = new GroupMembership(leaderGroupIds, memberGroupIds);
 
         String profileImageUrl = s3UploadPresignedUrlService.getUserPublicUrl(user.getProfileImageUrl());
         return UserInfoResponse.of(user, groups, profileImageUrl);


### PR DESCRIPTION
### 관련 이슈
- close #339 

### 기존 문제점  
- 기존에는 `Map<String, List<String>> groups = Map.of("leaderOf", leaderGroupIds, "memberOf", memberGroupIds);` 형태로 그룹 정보를 담고 있었습니다.  
- 이 방식은 구조가 명확하지 않고, 키 문자열("leaderOf", "memberOf")이 하드코딩되어 있어 오타나 변경 시 컴파일러가 잡아주지 못하는 문제가 있었습니다.  
- 또한 `UserInfoResponse` DTO 내에서도 `Map` 타입으로 정의되어 있어, 해당 데이터 구조를 사용하는 쪽에서 항상 키 이름을 인지해야 하는 불편함이 있었습니다.

---

### 바꾼 내용  
`GroupMembership`이라는 전용 DTO 클래스를 새로 정의하여,  
`leaderGroupIds`와 `memberGroupIds`를 각각 명확한 필드로 관리하도록 변경했습니다.  
```java
public record GroupMembership(
    List<String> leaderGroupIds,
    List<String> memberGroupIds
) {}
```

---


### 변경 후 
- 데이터 구조가 명시적으로 표현되어 코드 가독성이 높아졌습니다.
- Map의 문자열 키("leaderOf", "memberOf") 의존을 제거하여 컴파일 타임 안정성이 확보되었습니다.
- IDE 자동 완성과 타입 추론이 가능해져, 이후 유지보수나 확장 시 훨씬 편리합니다.
- JSON 응답 구조가 DTO 클래스 구조와 일치해서 관리하기 쉽습니다.

### 추가 의견
- Map은 key-value 기반의 비정형 데이터 구조이기 때문에, 구조가 고정된 경우에는 의도를 드러내기 어렵고 타입 안정성이 떨어집니다. 이번 변경을 통해 데이터의 의미를 명확히 표현하면서, 정적 타입 언어의 장점을 살릴 수 있도록 개선했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal data structure organization for group membership information handling to enhance code maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->